### PR TITLE
fix: execute valid bash cmd when running init as root

### DIFF
--- a/internal/cli/machine_test.go
+++ b/internal/cli/machine_test.go
@@ -1,0 +1,19 @@
+package cli
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestInstallCmd(t *testing.T) {
+	t.Run("root", func(t *testing.T) {
+		cmd := installCmd("root")
+		assert.NotContains(t, cmd, "sudo")
+	})
+
+	t.Run("nonroot", func(t *testing.T) {
+		cmd := installCmd("nonroot")
+		assert.Contains(t, cmd, "sudo")
+	})
+}


### PR DESCRIPTION
When executed as root, the bash command generated contained a bunch of quotes due to the empty `sudoPrefix` and `env`. This changes the code to emit plain pipe to bash when executed as root.

Closes #19.