### PR TITLE
feat: add ssh_key_file field to connections config

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -92,7 +92,7 @@ func (cli *CLI) ConnectCluster(ctx context.Context, clusterName string) (*client
 			return nil, fmt.Errorf("parse SSH connection %q: %w", conn.SSH, err)
 		}
 
-		keyPath := fs.ExpandHomeDir(conn.IdentityFile)
+		keyPath := fs.ExpandHomeDir(conn.SSHKeyFile)
 
 		sshConfig := &connector.SSHConnectorConfig{
 			User:    user,
@@ -166,8 +166,8 @@ func (cli *CLI) initRemoteMachine(
 
 	// Save the machine's SSH connection details in the cluster config.
 	connCfg := config.MachineConnection{
-		SSH:          config.NewSSHDestination(remoteMachine.User, remoteMachine.Host, remoteMachine.Port),
-		IdentityFile: remoteMachine.KeyPath,
+		SSH:        config.NewSSHDestination(remoteMachine.User, remoteMachine.Host, remoteMachine.Port),
+		SSHKeyFile: remoteMachine.KeyPath,
 	}
 	cli.config.Clusters[clusterName].Connections = append(cli.config.Clusters[clusterName].Connections, connCfg)
 	if err = cli.config.Save(); err != nil {

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -4,15 +4,17 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/charmbracelet/huh"
-	"google.golang.org/protobuf/types/known/emptypb"
 	"net/netip"
 	"uncloud/internal/cli/client"
 	"uncloud/internal/cli/client/connector"
 	"uncloud/internal/cli/config"
+	"uncloud/internal/fs"
 	"uncloud/internal/machine"
 	"uncloud/internal/machine/api/pb"
 	"uncloud/internal/sshexec"
+
+	"github.com/charmbracelet/huh"
+	"google.golang.org/protobuf/types/known/emptypb"
 )
 
 const defaultClusterName = "default"
@@ -89,10 +91,14 @@ func (cli *CLI) ConnectCluster(ctx context.Context, clusterName string) (*client
 		if err != nil {
 			return nil, fmt.Errorf("parse SSH connection %q: %w", conn.SSH, err)
 		}
+
+		keyPath := fs.ExpandHomeDir(conn.IdentityFile)
+
 		sshConfig := &connector.SSHConnectorConfig{
-			User: user,
-			Host: host,
-			Port: port,
+			User:    user,
+			Host:    host,
+			Port:    port,
+			KeyPath: keyPath,
 		}
 		return client.New(ctx, connector.NewSSHConnector(sshConfig))
 	} else if conn.TCP.IsValid() {

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -163,9 +163,11 @@ func (cli *CLI) initRemoteMachine(
 			return fmt.Errorf("set current cluster: %w", err)
 		}
 	}
+
 	// Save the machine's SSH connection details in the cluster config.
 	connCfg := config.MachineConnection{
-		SSH: config.NewSSHDestination(remoteMachine.User, remoteMachine.Host, remoteMachine.Port),
+		SSH:          config.NewSSHDestination(remoteMachine.User, remoteMachine.Host, remoteMachine.Port),
+		IdentityFile: remoteMachine.KeyPath,
 	}
 	cli.config.Clusters[clusterName].Connections = append(cli.config.Clusters[clusterName].Connections, connCfg)
 	if err = cli.config.Save(); err != nil {

--- a/internal/cli/config/connection.go
+++ b/internal/cli/config/connection.go
@@ -14,11 +14,11 @@ const (
 )
 
 type MachineConnection struct {
-	SSH          SSHDestination `toml:"ssh,omitempty"`
-	TCP          netip.AddrPort `toml:"tcp,omitempty"`
-	Host         string         `toml:"host,omitempty"`
-	PublicKey    secret.Secret  `toml:"public_key,omitempty"`
-	IdentityFile string         `toml:"identity_file,omitempty"`
+	SSH        SSHDestination `toml:"ssh,omitempty"`
+	TCP        netip.AddrPort `toml:"tcp,omitempty"`
+	Host       string         `toml:"host,omitempty"`
+	PublicKey  secret.Secret  `toml:"public_key,omitempty"`
+	SSHKeyFile string         `toml:"ssh_key_file,omitempty"`
 }
 
 // SSHDestination represents an SSH destination string in the canonical form of "user@host:port".

--- a/internal/cli/config/connection.go
+++ b/internal/cli/config/connection.go
@@ -14,10 +14,11 @@ const (
 )
 
 type MachineConnection struct {
-	SSH       SSHDestination `toml:"ssh,omitempty"`
-	TCP       netip.AddrPort `toml:"tcp,omitempty"`
-	Host      string         `toml:"host,omitempty"`
-	PublicKey secret.Secret  `toml:"public_key,omitempty"`
+	SSH          SSHDestination `toml:"ssh,omitempty"`
+	TCP          netip.AddrPort `toml:"tcp,omitempty"`
+	Host         string         `toml:"host,omitempty"`
+	PublicKey    secret.Secret  `toml:"public_key,omitempty"`
+	IdentityFile string         `toml:"identity_file,omitempty"`
 }
 
 // SSHDestination represents an SSH destination string in the canonical form of "user@host:port".

--- a/internal/fs/fs.go
+++ b/internal/fs/fs.go
@@ -13,9 +13,11 @@ func ExpandHomeDir(path string) string {
 		return path
 	}
 	if path[0] == '~' {
-		// TODO: Improve compat with other OSes
-		path = strings.Replace(path, "~", "${HOME}", 1)
-		return os.ExpandEnv(path)
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return path
+		}
+		return strings.Replace(path, "~", home, 1)
 	}
 	return path
 }

--- a/internal/fs/fs.go
+++ b/internal/fs/fs.go
@@ -5,7 +5,20 @@ import (
 	"os"
 	"os/user"
 	"strconv"
+	"strings"
 )
+
+func ExpandHomeDir(path string) string {
+	if len(path) == 0 {
+		return path
+	}
+	if path[0] == '~' {
+		// TODO: Improve compat with other OSes
+		path = strings.Replace(path, "~", "${HOME}", 1)
+		return os.ExpandEnv(path)
+	}
+	return path
+}
 
 // LookupUIDGID returns the user and group IDs for the given username.
 func LookupUIDGID(username string) (uid, gid int, err error) {

--- a/internal/fs/fs_test.go
+++ b/internal/fs/fs_test.go
@@ -1,0 +1,22 @@
+package fs
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestExpandHomeDir(t *testing.T) {
+	t.Run("empty", func(t *testing.T) {
+		assert.Equal(t, "", ExpandHomeDir(""))
+	})
+
+	t.Run("no home", func(t *testing.T) {
+		assert.Equal(t, "/path", ExpandHomeDir("/path"))
+	})
+
+	t.Run("home", func(t *testing.T) {
+		t.Setenv("HOME", "/home/user")
+		assert.Equal(t, "/home/user/path", ExpandHomeDir("~/path"))
+	})
+}

--- a/internal/sshexec/ssh.go
+++ b/internal/sshexec/ssh.go
@@ -2,12 +2,13 @@ package sshexec
 
 import (
 	"fmt"
-	"golang.org/x/crypto/ssh"
-	"golang.org/x/crypto/ssh/agent"
 	"net"
 	"os"
 	"strconv"
 	"time"
+
+	"golang.org/x/crypto/ssh"
+	"golang.org/x/crypto/ssh/agent"
 )
 
 func Connect(user, host string, port int, sshKeyPath string) (*ssh.Client, error) {
@@ -34,6 +35,9 @@ func Connect(user, host string, port int, sshKeyPath string) (*ssh.Client, error
 	}
 
 	keyAuth, err := privateKeyAuth(sshKeyPath)
+	if err != nil {
+		return nil, err
+	}
 	config := &ssh.ClientConfig{
 		User:            user,
 		Auth:            []ssh.AuthMethod{keyAuth},


### PR DESCRIPTION
This enables private key authentication by setting the `identity_file` field under a connection in `~/.config/uncloud/config.toml`. It also fixes a possible nil panic in this code path.

```
current_cluster = "default"

[clusters]
[clusters.default]

[[clusters.default.connections]]
ssh = "root@<redacted>"
identity_file = "~/.ssh/id_github"
```