### PR TITLE
feat: add version flag to main cmd

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -24,6 +24,8 @@ builds:
     goarch:
       - amd64
       - arm64
+    ldflags:
+      - -s -w -X github.com/psviderski/uncloud/internal/version.version={{ .Version }}
 
   - id: uncloudd
     main: ./cmd/uncloudd
@@ -35,6 +37,8 @@ builds:
     goarch:
       - amd64
       - arm64
+    ldflags:
+      - -s -w -X github.com/psviderski/uncloud/internal/version.version={{ .Version }}
 
 archives:
   - id: uncloud

--- a/cmd/uncloud/main.go
+++ b/cmd/uncloud/main.go
@@ -15,6 +15,7 @@ import (
 	"github.com/psviderski/uncloud/internal/cli"
 	"github.com/psviderski/uncloud/internal/cli/config"
 	"github.com/psviderski/uncloud/internal/fs"
+	"github.com/psviderski/uncloud/internal/version"
 	"github.com/spf13/cobra"
 )
 
@@ -28,6 +29,7 @@ func main() {
 	cmd := &cobra.Command{
 		Use:           "uncloud",
 		Short:         "A CLI tool for managing Uncloud resources such as clusters, machines, and services.",
+		Version:       version.String(),
 		SilenceUsage:  true,
 		SilenceErrors: true,
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,0 +1,7 @@
+package version
+
+var version string
+
+func String() string {
+	return version
+}


### PR DESCRIPTION
Closes #42.

This adds a `--version` flag to the main Cobra command.

Since this only applies to the main command this shouldn't conflict `--version` flags in subcommands.