### PR TITLE
feat: Label new volumes as managed by uncloud

### DIFF
--- a/internal/machine/docker/server.go
+++ b/internal/machine/docker/server.go
@@ -345,6 +345,12 @@ func (s *Server) CreateVolume(ctx context.Context, req *pb.CreateVolumeRequest) 
 		return nil, status.Errorf(codes.InvalidArgument, "unmarshal options: %v", err)
 	}
 
+	// Always add the managed label to the volume to indicate that it is managed by Uncloud.
+	if opts.Labels == nil {
+		opts.Labels = make(map[string]string)
+	}
+	opts.Labels[api.LabelManaged] = ""
+
 	vol, err := s.client.VolumeCreate(ctx, opts)
 	if err != nil {
 		return nil, status.Error(codes.Internal, err.Error())

--- a/test/e2e/compose_deploy_test.go
+++ b/test/e2e/compose_deploy_test.go
@@ -121,6 +121,9 @@ func TestComposeDeployment(t *testing.T) {
 		})
 		require.NoError(t, err)
 		assert.Len(t, volumes, 2, "Expected 2 volumes to be created")
+		// Check that the volumes have the correct labels
+		assert.Equal(t, map[string]string{"uncloud.managed": ""}, volumes[0].Volume.Labels)
+		assert.Equal(t, map[string]string{"uncloud.managed": ""}, volumes[1].Volume.Labels)
 
 		data1Volume, data2Volume := volumes[0], volumes[1]
 		if volumes[0].Volume.Name == "test-compose-volumes-data2" {


### PR DESCRIPTION
This is a first step to address https://github.com/psviderski/uncloud/issues/59; we'll be labeling all new volumes with "uncloud.managed" label (similar to how uncloud containers are now labeled).

Haven't updated ListVolumes and RemoveVolume methods yet since that will break the existing installations and needs some sort of upgrade path. A simple one could be: updating the deploy procedure to (force-)label any volume that is used by any uncloud service for now, lmk what you think @psviderski 
