### PR TITLE
feat: set default log driver for service containers to 'local'

### DIFF
--- a/pkg/api/service.go
+++ b/pkg/api/service.go
@@ -203,7 +203,8 @@ func (s *ContainerSpec) SetDefaults() ContainerSpec {
 	spec := s.Clone()
 	if spec.LogDriver == nil {
 		spec.LogDriver = &LogDriver{
-			Name: "local",
+			Name:    "local",
+			Options: map[string]string{},
 		}
 	}
 	if spec.PullPolicy == "" {

--- a/test/e2e/assert.go
+++ b/test/e2e/assert.go
@@ -62,7 +62,6 @@ func assertContainerMatchesSpec(t *testing.T, ctr api.ServiceContainer, spec api
 	assert.Equal(t, spec.Container.Init, ctr.HostConfig.Init)
 	assert.True(t, strings.HasPrefix(ctr.Name, spec.Name+"-"))
 
-	// If LogDriver is not set, any log driver set as default in the Docker daemon config could be used.
 	if spec.Container.LogDriver != nil {
 		assert.Equal(t, spec.Container.LogDriver.Name, ctr.HostConfig.LogConfig.Type)
 		assert.Equal(t, spec.Container.LogDriver.Options, ctr.HostConfig.LogConfig.Config)


### PR DESCRIPTION
Fix https://github.com/psviderski/uncloud/issues/49