### PR TITLE
Fix issue #66: prevent race condition with Docker network creation

### DIFF
--- a/internal/machine/machine.go
+++ b/internal/machine/machine.go
@@ -13,6 +13,7 @@ import (
 	"path/filepath"
 	"slices"
 	"strconv"
+	"sync"
 
 	"github.com/docker/docker/client"
 	"github.com/docker/go-connections/sockets"
@@ -151,6 +152,8 @@ type Machine struct {
 	initialised chan struct{}
 	// networkReady is signalled when the Docker network is configured and ready for containers.
 	networkReady chan struct{}
+	// networkReadyMu protects networkReady channel operations
+	networkReadyMu sync.RWMutex
 
 	// store is the cluster store backed by a distributed Corrosion database.
 	store   *store.Store
@@ -248,7 +251,9 @@ func NewMachine(config *Config) (*Machine, error) {
 	internalDNSIP := func() netip.Addr {
 		return m.IP()
 	}
-	m.docker = machinedocker.NewServer(dockerCli, db, internalDNSIP, machinedocker.WithNetworkReady(m.IsNetworkReady))
+	m.docker = machinedocker.NewServer(dockerCli, db, internalDNSIP, 
+		machinedocker.WithNetworkReady(m.IsNetworkReady),
+		machinedocker.WithWaitForNetworkReady(m.WaitForNetworkReady))
 	m.localMachineServer = newGRPCServer(m, c, m.docker)
 
 	if m.Initialised() {
@@ -370,7 +375,9 @@ func (m *Machine) Run(ctx context.Context) error {
 					var err error
 					
 					// Reset networkReady channel for the new cluster configuration
+					m.networkReadyMu.Lock()
 					m.networkReady = make(chan struct{})
+					m.networkReadyMu.Unlock()
 
 					m.cluster.UpdateMachineID(m.state.ID)
 
@@ -794,12 +801,37 @@ func (m *Machine) IsNetworkReady() bool {
 		return true
 	}
 	
-	// Check if network is ready by checking if the networkReady channel has been signaled
+	// Check if network is ready by checking if the networkReady channel has been closed
+	m.networkReadyMu.RLock()
+	defer m.networkReadyMu.RUnlock()
+	
 	select {
 	case <-m.networkReady:
 		return true
 	default:
 		return false
+	}
+}
+
+// WaitForNetworkReady waits for the Docker network to be ready for containers.
+// It returns nil when the network is ready or an error if the context is cancelled.
+func (m *Machine) WaitForNetworkReady(ctx context.Context) error {
+	if !m.Initialised() {
+		// If machine is not initialized, there's no network to wait for
+		return nil
+	}
+	
+	// Get a copy of the channel to wait on
+	m.networkReadyMu.RLock()
+	networkReady := m.networkReady
+	m.networkReadyMu.RUnlock()
+	
+	// Wait for network to be ready or context to be cancelled
+	select {
+	case <-networkReady:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
 	}
 }
 

--- a/internal/machine/network.go
+++ b/internal/machine/network.go
@@ -231,11 +231,7 @@ func (nc *networkController) prepareAndWatchDocker(ctx context.Context) error {
 	slog.Info("Docker network configured.")
 
 	// Signal that the Docker network is ready for containers
-	select {
-	case nc.networkReady <- struct{}{}:
-	default:
-		// Channel might be closed or full, which is fine
-	}
+	close(nc.networkReady)
 
 	slog.Info("Watching Docker containers and syncing them to cluster store.")
 	// Retry to watch and sync containers until the context is done.


### PR DESCRIPTION
 Fixes race condition in CI tests where containers fail to start with "network uncloud not found" error. The issue occurred because the machine API server became ready before the Docker network was fully configured, allowing container operations to
  proceed before the network infrastructure was available.

  Problem

  - Tests occasionally failed on CI with error: 
  `start container: rpc error: code = NotFound desc = Error response from daemon: network uncloud not found`
  - Race condition between machine API readiness and Docker network creation
  - The machine signals readiness when API servers start, but network controller runs asynchronously
  - Containers could be started before the "uncloud" Docker network was created

  Solution

  Implemented a network readiness synchronization mechanism:

  1. Added networkReady channel to Machine struct to track network status
  2. Modified network controller to signal when Docker network is configured
  3. Updated Docker server to check network readiness before starting containers
  4. Applied Functional Options pattern for clean, extensible API design

  Key Changes

  - internal/machine/machine.go: Added network readiness tracking and IsNetworkReady() method
  - internal/machine/network.go: Signal network readiness after Docker network creation
  - internal/machine/docker/server.go: Check network readiness in StartContainer() with Functional Options pattern

  Behavior

  - Non-cluster machines: Network considered ready immediately (no cluster network needed)
  - Cluster machines: Network readiness checked before container operations
  - Cluster joining: Network readiness reset and re-signaled for new configuration

  Testing

  - Resolves intermittent failures in TestComposeDeployment tests
  - Maintains backward compatibility with existing API
  - No impact on normal operation flow

  Related

  Closes #66