### PR TITLE
feat: add support for standard compose ports directive

### DIFF
--- a/internal/machine/docker/server.go
+++ b/internal/machine/docker/server.go
@@ -80,11 +80,11 @@ func NewServer(cli *client.Client, db *sqlx.DB, internalDNSIP func() netip.Addr,
 		db:            db,
 		internalDNSIP: internalDNSIP,
 	}
-	
+
 	for _, opt := range opts {
 		opt(s)
 	}
-	
+
 	return s
 }
 

--- a/internal/machine/machine.go
+++ b/internal/machine/machine.go
@@ -251,7 +251,7 @@ func NewMachine(config *Config) (*Machine, error) {
 	internalDNSIP := func() netip.Addr {
 		return m.IP()
 	}
-	m.docker = machinedocker.NewServer(dockerCli, db, internalDNSIP, 
+	m.docker = machinedocker.NewServer(dockerCli, db, internalDNSIP,
 		machinedocker.WithNetworkReady(m.IsNetworkReady),
 		machinedocker.WithWaitForNetworkReady(m.WaitForNetworkReady))
 	m.localMachineServer = newGRPCServer(m, c, m.docker)
@@ -373,7 +373,7 @@ func (m *Machine) Run(ctx context.Context) error {
 				// It can be reset when leaving the cluster and then re-initialised again with a new configuration.
 				case <-m.initialised:
 					var err error
-					
+
 					// Reset networkReady channel for the new cluster configuration
 					m.networkReadyMu.Lock()
 					m.networkReady = make(chan struct{})
@@ -800,11 +800,11 @@ func (m *Machine) IsNetworkReady() bool {
 		// If machine is not initialized, there's no network to check
 		return true
 	}
-	
+
 	// Check if network is ready by checking if the networkReady channel has been closed
 	m.networkReadyMu.RLock()
 	defer m.networkReadyMu.RUnlock()
-	
+
 	select {
 	case <-m.networkReady:
 		return true
@@ -820,12 +820,12 @@ func (m *Machine) WaitForNetworkReady(ctx context.Context) error {
 		// If machine is not initialized, there's no network to wait for
 		return nil
 	}
-	
+
 	// Get a copy of the channel to wait on
 	m.networkReadyMu.RLock()
 	networkReady := m.networkReady
 	m.networkReadyMu.RUnlock()
-	
+
 	// Wait for network to be ready or context to be cancelled
 	select {
 	case <-networkReady:

--- a/pkg/client/compose/port.go
+++ b/pkg/client/compose/port.go
@@ -2,6 +2,10 @@ package compose
 
 import (
 	"fmt"
+	"net/netip"
+	"strconv"
+	"strings"
+
 	"github.com/compose-spec/compose-go/v2/types"
 	"github.com/psviderski/uncloud/pkg/api"
 )
@@ -10,20 +14,49 @@ const PortsExtensionKey = "x-ports"
 
 type PortsSource []string
 
-// TransformServicesPortsExtension transforms the ports extension of all services in the project by replacing a string
-// representation of each port with a parsed PortSpec.
+// transformServicesPortsExtension transforms both standard 'ports' and 'x-ports' to PortSpecs.
+// Standard 'ports' directive is converted to x-ports string format first, then parsed.
 func transformServicesPortsExtension(project *types.Project) (*types.Project, error) {
 	return project.WithServicesTransform(func(name string, service types.ServiceConfig) (types.ServiceConfig, error) {
-		ports, ok := service.Extensions[PortsExtensionKey].(PortsSource)
-		if !ok {
+		// Check for mutual exclusivity
+		hasStandardPorts := len(service.Ports) > 0
+		hasXPorts := service.Extensions[PortsExtensionKey] != nil
+
+		if hasStandardPorts && hasXPorts {
+			return service, fmt.Errorf("service %q cannot specify both 'ports' and 'x-ports' directives, use only one", name)
+		}
+
+		var portsSource PortsSource
+		var err error
+
+		if hasStandardPorts {
+			// Convert standard ports to x-ports string format
+			portsSource, err = convertStandardPortsToXPorts(service.Ports)
+			if err != nil {
+				return service, fmt.Errorf("convert standard ports for service %q: %w", name, err)
+			}
+		} else if hasXPorts {
+			// Use existing x-ports
+			var ok bool
+			portsSource, ok = service.Extensions[PortsExtensionKey].(PortsSource)
+			if !ok {
+				return service, nil
+			}
+		} else {
+			// No ports specified
 			return service, nil
 		}
 
-		specs, err := transformPortsExtension(ports)
+		// Parse the port strings using existing logic
+		specs, err := transformPortsExtension(portsSource)
 		if err != nil {
 			return service, err
 		}
 
+		// Ensure extensions map exists
+		if service.Extensions == nil {
+			service.Extensions = make(types.Extensions)
+		}
 		service.Extensions[PortsExtensionKey] = specs
 		return service, nil
 	})
@@ -40,4 +73,290 @@ func transformPortsExtension(ports PortsSource) ([]api.PortSpec, error) {
 	}
 
 	return specs, nil
+}
+
+// expandPortRange expands a port range like "3000-3005" into individual port configs
+func expandPortRange(basePort types.ServicePortConfig) ([]types.ServicePortConfig, error) {
+	if !strings.Contains(basePort.Published, "-") {
+		// Not a range, return as-is
+		return []types.ServicePortConfig{basePort}, nil
+	}
+
+	parts := strings.Split(basePort.Published, "-")
+	if len(parts) != 2 {
+		return nil, fmt.Errorf("invalid port range format %q", basePort.Published)
+	}
+
+	startPort, err := strconv.ParseUint(strings.TrimSpace(parts[0]), 10, 16)
+	if err != nil {
+		return nil, fmt.Errorf("invalid start port in range %q: %w", basePort.Published, err)
+	}
+
+	endPort, err := strconv.ParseUint(strings.TrimSpace(parts[1]), 10, 16)
+	if err != nil {
+		return nil, fmt.Errorf("invalid end port in range %q: %w", basePort.Published, err)
+	}
+
+	if startPort >= endPort {
+		return nil, fmt.Errorf("invalid port range %q: start port must be less than end port", basePort.Published)
+	}
+
+	// Expand range into individual ports
+	var expandedPorts []types.ServicePortConfig
+	portDiff := endPort - startPort
+
+	for i := uint64(0); i <= portDiff; i++ {
+		expandedPort := basePort // Copy the base configuration
+
+		// Set published port
+		publishedPort := startPort + i
+		expandedPort.Published = strconv.FormatUint(publishedPort, 10)
+
+		// Set target port (aka container port)
+		// If target port range matches published port range, expand it too
+		// Otherwise, keep the same target port for all
+		if basePort.Target != 0 {
+			// For ranges, Docker Compose maps ports 1:1 by default
+			expandedPort.Target = basePort.Target + uint32(i)
+		}
+
+		expandedPorts = append(expandedPorts, expandedPort)
+	}
+
+	return expandedPorts, nil
+}
+
+// convertStandardPortsToXPorts converts standard Compose ports to x-ports string format.
+func convertStandardPortsToXPorts(ports []types.ServicePortConfig) (PortsSource, error) {
+	var xportsStrings []string
+
+	for _, port := range ports {
+		// Check if this port uses a range that should be expanded
+		expandedPorts, err := expandPortRange(port)
+		if err != nil {
+			return nil, err
+		}
+
+		// Convert each expanded port to x-ports string format
+		for _, expandedPort := range expandedPorts {
+			xportString, err := convertServicePortToXPortString(expandedPort)
+			if err != nil {
+				return nil, err
+			}
+			xportsStrings = append(xportsStrings, xportString)
+		}
+	}
+
+	return PortsSource(xportsStrings), nil
+}
+
+// portStringBuilder provides a professional way to build x-ports format strings
+// with comprehensive validation and support for Docker Compose specification.
+type portStringBuilder struct {
+	hostIP      string
+	published   string
+	target      uint32
+	protocol    string
+	mode        string
+	name        string
+	appProtocol string
+}
+
+// newPortStringBuilder creates a new builder from ServicePortConfig with validation
+func newPortStringBuilder(port types.ServicePortConfig) (*portStringBuilder, error) {
+	if port.Target == 0 {
+		return nil, fmt.Errorf("container port (target) is required")
+	}
+
+	builder := &portStringBuilder{
+		hostIP:      port.HostIP,
+		published:   port.Published,
+		target:      port.Target,
+		protocol:    port.Protocol,
+		mode:        port.Mode,
+		name:        port.Name,
+		appProtocol: port.AppProtocol,
+	}
+
+	// Apply defaults according to Docker Compose specification
+	if builder.protocol == "" {
+		builder.protocol = "tcp"
+	}
+	if builder.mode == "" {
+		builder.mode = "ingress"
+	}
+
+	return builder, nil
+}
+
+// validateHostIP validates the host IP address format including IPv6 support
+func (b *portStringBuilder) validateHostIP() error {
+	if b.hostIP == "" {
+		return nil
+	}
+
+	// Parse the IP address to ensure it's valid
+	if _, err := netip.ParseAddr(b.hostIP); err != nil {
+		return fmt.Errorf("invalid host IP address %q: %w", b.hostIP, err)
+	}
+
+	return nil
+}
+
+// validateProtocol validates the protocol against allowed values
+func (b *portStringBuilder) validateProtocol() error {
+	switch strings.ToLower(b.protocol) {
+	case "tcp", "udp", "http", "https":
+		return nil
+	default:
+		return fmt.Errorf("unsupported protocol %q, supported protocols: tcp, udp, http, https", b.protocol)
+	}
+}
+
+// validateMode validates the port mode
+func (b *portStringBuilder) validateMode() error {
+	switch b.mode {
+	case "ingress", "host":
+		return nil
+	default:
+		return fmt.Errorf("unsupported port mode %q, supported modes: ingress, host", b.mode)
+	}
+}
+
+// validatePublishedPort validates the published port format and range
+func (b *portStringBuilder) validatePublishedPort() error {
+	if b.published == "" {
+		return nil
+	}
+
+	// Port ranges should not reach this function as they are expanded earlier
+	if strings.Contains(b.published, "-") {
+		return fmt.Errorf("port ranges should be expanded before string building, got: %q", b.published)
+	}
+
+	// Single port validation
+	port, err := strconv.ParseUint(b.published, 10, 16)
+	if err != nil {
+		return fmt.Errorf("invalid published port %q: %w", b.published, err)
+	}
+
+	if port == 0 || port > 65535 {
+		return fmt.Errorf("published port %d out of valid range (1-65535)", port)
+	}
+
+	return nil
+}
+
+// validatePortRange validates port range format like "3000-3005"
+func (b *portStringBuilder) validatePortRange(portRange string) error {
+	parts := strings.Split(portRange, "-")
+	if len(parts) != 2 {
+		return fmt.Errorf("invalid port range format %q, expected format: startPort-endPort", portRange)
+	}
+
+	startPort, err := strconv.ParseUint(strings.TrimSpace(parts[0]), 10, 16)
+	if err != nil {
+		return fmt.Errorf("invalid start port in range %q: %w", portRange, err)
+	}
+
+	endPort, err := strconv.ParseUint(strings.TrimSpace(parts[1]), 10, 16)
+	if err != nil {
+		return fmt.Errorf("invalid end port in range %q: %w", portRange, err)
+	}
+
+	if startPort == 0 || startPort > 65535 || endPort == 0 || endPort > 65535 {
+		return fmt.Errorf("port range %q contains ports outside valid range (1-65535)", portRange)
+	}
+
+	if startPort >= endPort {
+		return fmt.Errorf("invalid port range %q: start port must be less than end port", portRange)
+	}
+
+	return nil
+}
+
+// validate performs comprehensive validation of all fields
+func (b *portStringBuilder) validate() error {
+	if err := b.validateHostIP(); err != nil {
+		return err
+	}
+	if err := b.validateProtocol(); err != nil {
+		return err
+	}
+	if err := b.validateMode(); err != nil {
+		return err
+	}
+	if err := b.validatePublishedPort(); err != nil {
+		return err
+	}
+
+	// Additional mode-specific validations
+	if b.mode == "host" && b.published == "" {
+		return fmt.Errorf("published port is required in host mode")
+	}
+
+	return nil
+}
+
+// formatHostIP formats the host IP for inclusion in x-ports string
+func (b *portStringBuilder) formatHostIP() string {
+	if b.hostIP == "" {
+		return ""
+	}
+
+	// Check if it's an IPv6 address that needs brackets
+	if addr, err := netip.ParseAddr(b.hostIP); err == nil && addr.Is6() {
+		return fmt.Sprintf("[%s]", b.hostIP)
+	}
+
+	return b.hostIP
+}
+
+// build constructs the x-ports format string using strings.Builder for optimal performance
+func (b *portStringBuilder) build() (string, error) {
+	if err := b.validate(); err != nil {
+		return "", err
+	}
+
+	var builder strings.Builder
+
+	// Add host IP if specified
+	if formattedIP := b.formatHostIP(); formattedIP != "" {
+		builder.WriteString(formattedIP)
+		builder.WriteString(":")
+	}
+
+	// Add published port if specified
+	if b.published != "" {
+		builder.WriteString(b.published)
+		builder.WriteString(":")
+	}
+
+	// Add container port (required)
+	builder.WriteString(strconv.FormatUint(uint64(b.target), 10))
+
+	// Add protocol if not default TCP or in host mode
+	if b.protocol != "tcp" || b.mode == "host" {
+		builder.WriteString("/")
+		builder.WriteString(b.protocol)
+	}
+
+	// Add mode if host mode (ingress is default and not included)
+	if b.mode == "host" {
+		builder.WriteString("@host")
+	}
+
+	return builder.String(), nil
+}
+
+// convertServicePortToXPortString converts a single ServicePortConfig to x-ports string format.
+// This function now uses a professional builder pattern with comprehensive validation
+// and full support for Docker Compose specification including IPv6 and port ranges.
+func convertServicePortToXPortString(port types.ServicePortConfig) (string, error) {
+	builder, err := newPortStringBuilder(port)
+	if err != nil {
+		return "", err
+	}
+
+	return builder.build()
 }

--- a/pkg/client/compose/port.go
+++ b/pkg/client/compose/port.go
@@ -82,21 +82,6 @@ func convertServicePortConfigToPortSpec(port types.ServicePortConfig) (api.PortS
 		Protocol:      port.Protocol,
 		Mode:          port.Mode,
 	}
-
-	// Apply defaults according to Docker Compose specification
-	if spec.Protocol == "" {
-		spec.Protocol = "tcp"
-	}
-	if spec.Mode == "" {
-		spec.Mode = "ingress"
-	}
-
-	if spec.Mode == "ingress" && spec.Protocol != "http" && spec.Protocol != "https" {
-		if port.Published != "" {
-			spec.Mode = "host"
-		}
-	}
-
 	// Set published port if specified
 	if port.Published != "" {
 		publishedPort, err := strconv.ParseUint(port.Published, 10, 16)
@@ -114,6 +99,9 @@ func convertServicePortConfigToPortSpec(port types.ServicePortConfig) (api.PortS
 		}
 		spec.HostIP = hostIP
 	}
+
+	// Apply defaults according to uncloud
+	spec.AdjustUncloudMode()
 
 	// Validate the resulting spec
 	if err := spec.Validate(); err != nil {

--- a/pkg/client/compose/port.go
+++ b/pkg/client/compose/port.go
@@ -15,7 +15,6 @@ const PortsExtensionKey = "x-ports"
 type PortsSource []string
 
 // transformServicesPortsExtension transforms both standard 'ports' and 'x-ports' to PortSpecs.
-// Standard 'ports' directive is converted to x-ports string format first, then parsed.
 func transformServicesPortsExtension(project *types.Project) (*types.Project, error) {
 	return project.WithServicesTransform(func(name string, service types.ServiceConfig) (types.ServiceConfig, error) {
 		// Check for mutual exclusivity
@@ -26,31 +25,34 @@ func transformServicesPortsExtension(project *types.Project) (*types.Project, er
 			return service, fmt.Errorf("service %q cannot specify both 'ports' and 'x-ports' directives, use only one", name)
 		}
 
-		var portsSource PortsSource
-		var err error
+		var (
+			specs []api.PortSpec
+			err   error
+		)
 
 		if hasStandardPorts {
-			// Convert standard ports to x-ports string format
-			portsSource, err = convertStandardPortsToXPorts(service.Ports)
+			// Convert standard ports directly to api.PortSpec
+			specs, err = convertStandardPortsToPortSpecs(service.Ports)
 			if err != nil {
 				return service, fmt.Errorf("convert standard ports for service %q: %w", name, err)
 			}
 		} else if hasXPorts {
-			// Use existing x-ports
+			// Use existing x-ports string-based processing for backward compatibility
+			var portsSource PortsSource
 			var ok bool
 			portsSource, ok = service.Extensions[PortsExtensionKey].(PortsSource)
 			if !ok {
 				return service, nil
 			}
+
+			// Parse the port strings using existing logic
+			specs, err = transformPortsExtension(portsSource)
+			if err != nil {
+				return service, err
+			}
 		} else {
 			// No ports specified
 			return service, nil
-		}
-
-		// Parse the port strings using existing logic
-		specs, err := transformPortsExtension(portsSource)
-		if err != nil {
-			return service, err
 		}
 
 		// Ensure extensions map exists
@@ -78,7 +80,6 @@ func transformPortsExtension(ports PortsSource) ([]api.PortSpec, error) {
 // expandPortRange expands a port range like "3000-3005" into individual port configs
 func expandPortRange(basePort types.ServicePortConfig) ([]types.ServicePortConfig, error) {
 	if !strings.Contains(basePort.Published, "-") {
-		// Not a range, return as-is
 		return []types.ServicePortConfig{basePort}, nil
 	}
 
@@ -126,9 +127,51 @@ func expandPortRange(basePort types.ServicePortConfig) ([]types.ServicePortConfi
 	return expandedPorts, nil
 }
 
-// convertStandardPortsToXPorts converts standard Compose ports to x-ports string format.
-func convertStandardPortsToXPorts(ports []types.ServicePortConfig) (PortsSource, error) {
-	var xportsStrings []string
+// convertServicePortConfigToPortSpec converts a single ServicePortConfig directly to api.PortSpec
+func convertServicePortConfigToPortSpec(port types.ServicePortConfig) (api.PortSpec, error) {
+	spec := api.PortSpec{
+		ContainerPort: uint16(port.Target),
+		Protocol:      port.Protocol,
+		Mode:          port.Mode,
+	}
+
+	// Apply defaults according to Docker Compose specification
+	if spec.Protocol == "" {
+		spec.Protocol = "tcp"
+	}
+	if spec.Mode == "" {
+		spec.Mode = "ingress"
+	}
+
+	// Set published port if specified
+	if port.Published != "" {
+		publishedPort, err := strconv.ParseUint(port.Published, 10, 16)
+		if err != nil {
+			return spec, fmt.Errorf("invalid published port %q: %w", port.Published, err)
+		}
+		spec.PublishedPort = uint16(publishedPort)
+	}
+
+	// Set host IP if specified
+	if port.HostIP != "" {
+		hostIP, err := netip.ParseAddr(port.HostIP)
+		if err != nil {
+			return spec, fmt.Errorf("invalid host IP %q: %w", port.HostIP, err)
+		}
+		spec.HostIP = hostIP
+	}
+
+	// Validate the resulting spec
+	if err := spec.Validate(); err != nil {
+		return spec, fmt.Errorf("invalid port configuration: %w", err)
+	}
+
+	return spec, nil
+}
+
+// convertStandardPortsToPortSpecs converts standard go-compose ports directly to api.PortSpecs
+func convertStandardPortsToPortSpecs(ports []types.ServicePortConfig) ([]api.PortSpec, error) {
+	var specs []api.PortSpec
 
 	for _, port := range ports {
 		// Check if this port uses a range that should be expanded
@@ -137,226 +180,15 @@ func convertStandardPortsToXPorts(ports []types.ServicePortConfig) (PortsSource,
 			return nil, err
 		}
 
-		// Convert each expanded port to x-ports string format
+		// Convert each expanded port directly to api.PortSpec
 		for _, expandedPort := range expandedPorts {
-			xportString, err := convertServicePortToXPortString(expandedPort)
+			spec, err := convertServicePortConfigToPortSpec(expandedPort)
 			if err != nil {
 				return nil, err
 			}
-			xportsStrings = append(xportsStrings, xportString)
+			specs = append(specs, spec)
 		}
 	}
 
-	return PortsSource(xportsStrings), nil
-}
-
-// portStringBuilder provides a professional way to build x-ports format strings
-// with comprehensive validation and support for Docker Compose specification.
-type portStringBuilder struct {
-	hostIP      string
-	published   string
-	target      uint32
-	protocol    string
-	mode        string
-	name        string
-	appProtocol string
-}
-
-// newPortStringBuilder creates a new builder from ServicePortConfig with validation
-func newPortStringBuilder(port types.ServicePortConfig) (*portStringBuilder, error) {
-	if port.Target == 0 {
-		return nil, fmt.Errorf("container port (target) is required")
-	}
-
-	builder := &portStringBuilder{
-		hostIP:      port.HostIP,
-		published:   port.Published,
-		target:      port.Target,
-		protocol:    port.Protocol,
-		mode:        port.Mode,
-		name:        port.Name,
-		appProtocol: port.AppProtocol,
-	}
-
-	// Apply defaults according to Docker Compose specification
-	if builder.protocol == "" {
-		builder.protocol = "tcp"
-	}
-	if builder.mode == "" {
-		builder.mode = "ingress"
-	}
-
-	return builder, nil
-}
-
-// validateHostIP validates the host IP address format including IPv6 support
-func (b *portStringBuilder) validateHostIP() error {
-	if b.hostIP == "" {
-		return nil
-	}
-
-	// Parse the IP address to ensure it's valid
-	if _, err := netip.ParseAddr(b.hostIP); err != nil {
-		return fmt.Errorf("invalid host IP address %q: %w", b.hostIP, err)
-	}
-
-	return nil
-}
-
-// validateProtocol validates the protocol against allowed values
-func (b *portStringBuilder) validateProtocol() error {
-	switch strings.ToLower(b.protocol) {
-	case "tcp", "udp", "http", "https":
-		return nil
-	default:
-		return fmt.Errorf("unsupported protocol %q, supported protocols: tcp, udp, http, https", b.protocol)
-	}
-}
-
-// validateMode validates the port mode
-func (b *portStringBuilder) validateMode() error {
-	switch b.mode {
-	case "ingress", "host":
-		return nil
-	default:
-		return fmt.Errorf("unsupported port mode %q, supported modes: ingress, host", b.mode)
-	}
-}
-
-// validatePublishedPort validates the published port format and range
-func (b *portStringBuilder) validatePublishedPort() error {
-	if b.published == "" {
-		return nil
-	}
-
-	// Port ranges should not reach this function as they are expanded earlier
-	if strings.Contains(b.published, "-") {
-		return fmt.Errorf("port ranges should be expanded before string building, got: %q", b.published)
-	}
-
-	// Single port validation
-	port, err := strconv.ParseUint(b.published, 10, 16)
-	if err != nil {
-		return fmt.Errorf("invalid published port %q: %w", b.published, err)
-	}
-
-	if port == 0 || port > 65535 {
-		return fmt.Errorf("published port %d out of valid range (1-65535)", port)
-	}
-
-	return nil
-}
-
-// validatePortRange validates port range format like "3000-3005"
-func (b *portStringBuilder) validatePortRange(portRange string) error {
-	parts := strings.Split(portRange, "-")
-	if len(parts) != 2 {
-		return fmt.Errorf("invalid port range format %q, expected format: startPort-endPort", portRange)
-	}
-
-	startPort, err := strconv.ParseUint(strings.TrimSpace(parts[0]), 10, 16)
-	if err != nil {
-		return fmt.Errorf("invalid start port in range %q: %w", portRange, err)
-	}
-
-	endPort, err := strconv.ParseUint(strings.TrimSpace(parts[1]), 10, 16)
-	if err != nil {
-		return fmt.Errorf("invalid end port in range %q: %w", portRange, err)
-	}
-
-	if startPort == 0 || startPort > 65535 || endPort == 0 || endPort > 65535 {
-		return fmt.Errorf("port range %q contains ports outside valid range (1-65535)", portRange)
-	}
-
-	if startPort >= endPort {
-		return fmt.Errorf("invalid port range %q: start port must be less than end port", portRange)
-	}
-
-	return nil
-}
-
-// validate performs comprehensive validation of all fields
-func (b *portStringBuilder) validate() error {
-	if err := b.validateHostIP(); err != nil {
-		return err
-	}
-	if err := b.validateProtocol(); err != nil {
-		return err
-	}
-	if err := b.validateMode(); err != nil {
-		return err
-	}
-	if err := b.validatePublishedPort(); err != nil {
-		return err
-	}
-
-	// Additional mode-specific validations
-	if b.mode == "host" && b.published == "" {
-		return fmt.Errorf("published port is required in host mode")
-	}
-
-	return nil
-}
-
-// formatHostIP formats the host IP for inclusion in x-ports string
-func (b *portStringBuilder) formatHostIP() string {
-	if b.hostIP == "" {
-		return ""
-	}
-
-	// Check if it's an IPv6 address that needs brackets
-	if addr, err := netip.ParseAddr(b.hostIP); err == nil && addr.Is6() {
-		return fmt.Sprintf("[%s]", b.hostIP)
-	}
-
-	return b.hostIP
-}
-
-// build constructs the x-ports format string using strings.Builder for optimal performance
-func (b *portStringBuilder) build() (string, error) {
-	if err := b.validate(); err != nil {
-		return "", err
-	}
-
-	var builder strings.Builder
-
-	// Add host IP if specified
-	if formattedIP := b.formatHostIP(); formattedIP != "" {
-		builder.WriteString(formattedIP)
-		builder.WriteString(":")
-	}
-
-	// Add published port if specified
-	if b.published != "" {
-		builder.WriteString(b.published)
-		builder.WriteString(":")
-	}
-
-	// Add container port (required)
-	builder.WriteString(strconv.FormatUint(uint64(b.target), 10))
-
-	// Add protocol if not default TCP or in host mode
-	if b.protocol != "tcp" || b.mode == "host" {
-		builder.WriteString("/")
-		builder.WriteString(b.protocol)
-	}
-
-	// Add mode if host mode (ingress is default and not included)
-	if b.mode == "host" {
-		builder.WriteString("@host")
-	}
-
-	return builder.String(), nil
-}
-
-// convertServicePortToXPortString converts a single ServicePortConfig to x-ports string format.
-// This function now uses a professional builder pattern with comprehensive validation
-// and full support for Docker Compose specification including IPv6 and port ranges.
-func convertServicePortToXPortString(port types.ServicePortConfig) (string, error) {
-	builder, err := newPortStringBuilder(port)
-	if err != nil {
-		return "", err
-	}
-
-	return builder.build()
+	return specs, nil
 }

--- a/pkg/client/compose/port_test.go
+++ b/pkg/client/compose/port_test.go
@@ -1,0 +1,742 @@
+package compose
+
+import (
+	"testing"
+
+	"github.com/compose-spec/compose-go/v2/types"
+	"github.com/psviderski/uncloud/pkg/api"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConvertServicePortToXPortString(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		port     types.ServicePortConfig
+		expected string
+		wantErr  string
+	}{
+		// Basic cases
+		{
+			name: "basic tcp port with published",
+			port: types.ServicePortConfig{
+				Target:    8080,
+				Published: "80",
+				Protocol:  "tcp",
+			},
+			expected: "80:8080",
+		},
+		{
+			name: "container port only",
+			port: types.ServicePortConfig{
+				Target: 8080,
+			},
+			expected: "8080",
+		},
+		{
+			name: "udp port",
+			port: types.ServicePortConfig{
+				Target:    8080,
+				Published: "80",
+				Protocol:  "udp",
+			},
+			expected: "80:8080/udp",
+		},
+		{
+			name: "host mode tcp",
+			port: types.ServicePortConfig{
+				Target:    8080,
+				Published: "80",
+				Protocol:  "tcp",
+				Mode:      "host",
+			},
+			expected: "80:8080/tcp@host",
+		},
+		{
+			name: "host mode udp",
+			port: types.ServicePortConfig{
+				Target:    8080,
+				Published: "80",
+				Protocol:  "udp",
+				Mode:      "host",
+			},
+			expected: "80:8080/udp@host",
+		},
+		{
+			name: "ingress mode explicit",
+			port: types.ServicePortConfig{
+				Target:    8080,
+				Published: "80",
+				Protocol:  "tcp",
+				Mode:      "ingress",
+			},
+			expected: "80:8080",
+		},
+		{
+			name: "with host IP",
+			port: types.ServicePortConfig{
+				Target:    8080,
+				Published: "80",
+				Protocol:  "tcp",
+				HostIP:    "127.0.0.1",
+			},
+			expected: "127.0.0.1:80:8080",
+		},
+		{
+			name: "with host IP and host mode",
+			port: types.ServicePortConfig{
+				Target:    8080,
+				Published: "80",
+				Protocol:  "tcp",
+				HostIP:    "127.0.0.1",
+				Mode:      "host",
+			},
+			expected: "127.0.0.1:80:8080/tcp@host",
+		},
+
+		// IPv6 support tests
+		{
+			name: "IPv6 address with brackets",
+			port: types.ServicePortConfig{
+				Target:    8080,
+				Published: "80",
+				Protocol:  "tcp",
+				HostIP:    "::1",
+			},
+			expected: "[::1]:80:8080",
+		},
+		{
+			name: "IPv6 full address",
+			port: types.ServicePortConfig{
+				Target:    8080,
+				Published: "80",
+				Protocol:  "tcp",
+				HostIP:    "2001:db8::1",
+				Mode:      "host",
+			},
+			expected: "[2001:db8::1]:80:8080/tcp@host",
+		},
+
+		// Protocol support tests
+		{
+			name: "http protocol",
+			port: types.ServicePortConfig{
+				Target:    8080,
+				Published: "80",
+				Protocol:  "http",
+			},
+			expected: "80:8080/http",
+		},
+		{
+			name: "https protocol",
+			port: types.ServicePortConfig{
+				Target:    8080,
+				Published: "443",
+				Protocol:  "https",
+			},
+			expected: "443:8080/https",
+		},
+
+		// Port range in single port converter should fail (ranges are expanded at higher level)
+		{
+			name: "port range should fail in single converter",
+			port: types.ServicePortConfig{
+				Target:    8080,
+				Published: "3000-3005",
+				Protocol:  "tcp",
+			},
+			wantErr: "port ranges should be expanded before string building",
+		},
+
+		// Edge cases and boundary tests
+		{
+			name: "port 1 (minimum)",
+			port: types.ServicePortConfig{
+				Target:    1,
+				Published: "1",
+				Protocol:  "tcp",
+			},
+			expected: "1:1",
+		},
+		{
+			name: "port 65535 (maximum)",
+			port: types.ServicePortConfig{
+				Target:    65535,
+				Published: "65535",
+				Protocol:  "tcp",
+			},
+			expected: "65535:65535",
+		},
+
+		// Name and AppProtocol fields (should not affect output but should be preserved)
+		{
+			name: "with name and app_protocol",
+			port: types.ServicePortConfig{
+				Target:      8080,
+				Published:   "80",
+				Protocol:    "tcp",
+				Name:        "web",
+				AppProtocol: "http",
+			},
+			expected: "80:8080",
+		},
+
+		// Error cases
+		{
+			name: "missing container port",
+			port: types.ServicePortConfig{
+				Published: "80",
+			},
+			wantErr: "container port (target) is required",
+		},
+		{
+			name: "invalid published port",
+			port: types.ServicePortConfig{
+				Target:    8080,
+				Published: "invalid",
+			},
+			wantErr: "invalid published port",
+		},
+		{
+			name: "unsupported mode",
+			port: types.ServicePortConfig{
+				Target:    8080,
+				Published: "80",
+				Mode:      "invalid",
+			},
+			wantErr: "unsupported port mode",
+		},
+		{
+			name: "invalid protocol",
+			port: types.ServicePortConfig{
+				Target:    8080,
+				Published: "80",
+				Protocol:  "invalid",
+			},
+			wantErr: "unsupported protocol",
+		},
+		{
+			name: "invalid IPv4 address",
+			port: types.ServicePortConfig{
+				Target:    8080,
+				Published: "80",
+				HostIP:    "999.999.999.999",
+			},
+			wantErr: "invalid host IP address",
+		},
+		{
+			name: "invalid IPv6 address",
+			port: types.ServicePortConfig{
+				Target:    8080,
+				Published: "80",
+				HostIP:    "::invalid",
+			},
+			wantErr: "invalid host IP address",
+		},
+		{
+			name: "port 0 (invalid)",
+			port: types.ServicePortConfig{
+				Target:    8080,
+				Published: "0",
+			},
+			wantErr: "published port 0 out of valid range",
+		},
+		{
+			name: "port too high",
+			port: types.ServicePortConfig{
+				Target:    8080,
+				Published: "99999",
+			},
+			wantErr: "invalid published port",
+		},
+		{
+			name: "host mode without published port",
+			port: types.ServicePortConfig{
+				Target: 8080,
+				Mode:   "host",
+			},
+			wantErr: "published port is required in host mode",
+		},
+		{
+			name: "invalid port range format",
+			port: types.ServicePortConfig{
+				Target:    8080,
+				Published: "3000-3005-4000",
+			},
+			wantErr: "port ranges should be expanded before string building",
+		},
+		{
+			name: "invalid port range - start >= end",
+			port: types.ServicePortConfig{
+				Target:    8080,
+				Published: "3005-3000",
+			},
+			wantErr: "port ranges should be expanded before string building",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			result, err := convertServicePortToXPortString(tt.port)
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestExpandPortRange(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		port     types.ServicePortConfig
+		expected []types.ServicePortConfig
+		wantErr  string
+	}{
+		{
+			name: "single port (no range)",
+			port: types.ServicePortConfig{
+				Target:    8080,
+				Published: "80",
+				Protocol:  "tcp",
+			},
+			expected: []types.ServicePortConfig{
+				{
+					Target:    8080,
+					Published: "80",
+					Protocol:  "tcp",
+				},
+			},
+		},
+		{
+			name: "simple port range",
+			port: types.ServicePortConfig{
+				Target:    8080,
+				Published: "3000-3002",
+				Protocol:  "tcp",
+				Mode:      "host",
+			},
+			expected: []types.ServicePortConfig{
+				{
+					Target:    8080,
+					Published: "3000",
+					Protocol:  "tcp",
+					Mode:      "host",
+				},
+				{
+					Target:    8081,
+					Published: "3001",
+					Protocol:  "tcp",
+					Mode:      "host",
+				},
+				{
+					Target:    8082,
+					Published: "3002",
+					Protocol:  "tcp",
+					Mode:      "host",
+				},
+			},
+		},
+		{
+			name: "port range with host IP",
+			port: types.ServicePortConfig{
+				Target:    9000,
+				Published: "5000-5001",
+				Protocol:  "udp",
+				HostIP:    "127.0.0.1",
+				Mode:      "host",
+			},
+			expected: []types.ServicePortConfig{
+				{
+					Target:    9000,
+					Published: "5000",
+					Protocol:  "udp",
+					HostIP:    "127.0.0.1",
+					Mode:      "host",
+				},
+				{
+					Target:    9001,
+					Published: "5001",
+					Protocol:  "udp",
+					HostIP:    "127.0.0.1",
+					Mode:      "host",
+				},
+			},
+		},
+		{
+			name: "large port range",
+			port: types.ServicePortConfig{
+				Target:    8000,
+				Published: "3000-3009",
+				Protocol:  "tcp",
+			},
+			expected: []types.ServicePortConfig{
+				{Target: 8000, Published: "3000", Protocol: "tcp"},
+				{Target: 8001, Published: "3001", Protocol: "tcp"},
+				{Target: 8002, Published: "3002", Protocol: "tcp"},
+				{Target: 8003, Published: "3003", Protocol: "tcp"},
+				{Target: 8004, Published: "3004", Protocol: "tcp"},
+				{Target: 8005, Published: "3005", Protocol: "tcp"},
+				{Target: 8006, Published: "3006", Protocol: "tcp"},
+				{Target: 8007, Published: "3007", Protocol: "tcp"},
+				{Target: 8008, Published: "3008", Protocol: "tcp"},
+				{Target: 8009, Published: "3009", Protocol: "tcp"},
+			},
+		},
+
+		// Error cases
+		{
+			name: "invalid range format",
+			port: types.ServicePortConfig{
+				Target:    8080,
+				Published: "3000-3001-3002",
+			},
+			wantErr: "invalid port range format",
+		},
+		{
+			name: "invalid start port",
+			port: types.ServicePortConfig{
+				Target:    8080,
+				Published: "abc-3001",
+			},
+			wantErr: "invalid start port in range",
+		},
+		{
+			name: "invalid end port",
+			port: types.ServicePortConfig{
+				Target:    8080,
+				Published: "3000-xyz",
+			},
+			wantErr: "invalid end port in range",
+		},
+		{
+			name: "start port >= end port",
+			port: types.ServicePortConfig{
+				Target:    8080,
+				Published: "3001-3000",
+			},
+			wantErr: "invalid port range",
+		},
+		{
+			name: "start port = end port",
+			port: types.ServicePortConfig{
+				Target:    8080,
+				Published: "3000-3000",
+			},
+			wantErr: "invalid port range",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			result, err := expandPortRange(tt.port)
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestConvertStandardPortsToXPorts_WithRanges(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		ports    []types.ServicePortConfig
+		expected PortsSource
+		wantErr  string
+	}{
+		{
+			name: "port range expansion",
+			ports: []types.ServicePortConfig{
+				{
+					Target:    8080,
+					Published: "3000-3002",
+					Protocol:  "tcp",
+				},
+			},
+			expected: PortsSource{"3000:8080", "3001:8081", "3002:8082"},
+		},
+		{
+			name: "mixed single ports and ranges",
+			ports: []types.ServicePortConfig{
+				{
+					Target:    8080,
+					Published: "80",
+					Protocol:  "tcp",
+				},
+				{
+					Target:    9000,
+					Published: "4000-4001",
+					Protocol:  "udp",
+				},
+			},
+			expected: PortsSource{"80:8080", "4000:9000/udp", "4001:9001/udp"},
+		},
+		{
+			name: "port range in host mode",
+			ports: []types.ServicePortConfig{
+				{
+					Target:    8080,
+					Published: "3000-3001",
+					Protocol:  "tcp",
+					Mode:      "host",
+					HostIP:    "127.0.0.1",
+				},
+			},
+			expected: PortsSource{"127.0.0.1:3000:8080/tcp@host", "127.0.0.1:3001:8081/tcp@host"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			result, err := convertStandardPortsToXPorts(tt.ports)
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestConvertStandardPortsToXPorts(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		ports    []types.ServicePortConfig
+		expected PortsSource
+		wantErr  string
+	}{
+		{
+			name: "multiple ports",
+			ports: []types.ServicePortConfig{
+				{Target: 8080, Published: "80", Protocol: "tcp"},
+				{Target: 8443, Published: "443", Protocol: "tcp", Mode: "host"},
+				{Target: 5353, Published: "53", Protocol: "udp"},
+			},
+			expected: PortsSource{"80:8080", "443:8443/tcp@host", "53:5353/udp"},
+		},
+		{
+			name:     "empty ports",
+			ports:    []types.ServicePortConfig{},
+			expected: PortsSource(nil),
+		},
+		{
+			name: "single port no published",
+			ports: []types.ServicePortConfig{
+				{Target: 8080},
+			},
+			expected: PortsSource{"8080"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			result, err := convertStandardPortsToXPorts(tt.ports)
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestTransformServicesPortsExtension_MutualExclusivity(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		content string
+		wantErr string
+	}{
+		{
+			name: "both ports and x-ports specified",
+			content: `
+services:
+  web:
+    image: nginx
+    ports:
+      - "80:8080"
+    x-ports:
+      - "443:8443/https"
+`,
+			wantErr: `service "web" cannot specify both 'ports' and 'x-ports' directives, use only one`,
+		},
+		{
+			name: "only ports specified",
+			content: `
+services:
+  web:
+    image: nginx
+    ports:
+      - "80:8080"
+`,
+		},
+		{
+			name: "only x-ports specified",
+			content: `
+services:
+  web:
+    image: nginx
+    x-ports:
+      - "80:8080/tcp@host"
+`,
+		},
+		{
+			name: "no ports specified",
+			content: `
+services:
+  web:
+    image: nginx
+`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			project, err := loadProjectFromContent(t, tt.content)
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr)
+				return
+			}
+
+			require.NoError(t, err)
+			
+			// Verify service exists
+			service, err := project.GetService("web")
+			require.NoError(t, err)
+			
+			// Check that ports were processed correctly
+			if specs, ok := service.Extensions[PortsExtensionKey].([]api.PortSpec); ok {
+				// Should have specs if ports were specified
+				assert.NotEmpty(t, specs)
+			}
+		})
+	}
+}
+
+func TestTransformServicesPortsExtension_StandardPorts(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		content  string
+		expected []api.PortSpec
+	}{
+		{
+			name: "standard ports short syntax",
+			content: `
+services:
+  web:
+    image: nginx
+    ports:
+      - "80:8080"
+      - "443:8443/tcp"
+      - "53:5353/udp"
+`,
+			expected: []api.PortSpec{
+				{ContainerPort: 8080, PublishedPort: 80, Protocol: "tcp", Mode: "ingress"},
+				{ContainerPort: 8443, PublishedPort: 443, Protocol: "tcp", Mode: "ingress"},
+				{ContainerPort: 5353, PublishedPort: 53, Protocol: "udp", Mode: "ingress"},
+			},
+		},
+		{
+			name: "standard ports long syntax",
+			content: `
+services:
+  web:
+    image: nginx
+    ports:
+      - target: 8080
+        published: 80
+        protocol: tcp
+        mode: ingress
+      - target: 8443
+        published: 443
+        protocol: tcp
+        mode: host
+`,
+			expected: []api.PortSpec{
+				{ContainerPort: 8080, PublishedPort: 80, Protocol: "tcp", Mode: "ingress"},
+				{ContainerPort: 8443, PublishedPort: 443, Protocol: "tcp", Mode: "host"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			project, err := loadProjectFromContent(t, tt.content)
+			require.NoError(t, err)
+
+			service, err := project.GetService("web")
+			require.NoError(t, err)
+
+			specs, ok := service.Extensions[PortsExtensionKey].([]api.PortSpec)
+			require.True(t, ok, "Service should have port specs")
+
+			assert.ElementsMatch(t, tt.expected, specs)
+		})
+	}
+}
+
+func TestTransformServicesPortsExtension_XPorts(t *testing.T) {
+	t.Parallel()
+
+	content := `
+services:
+  web:
+    image: nginx
+    x-ports:
+      - "80:8080/tcp"
+      - "443:8443/https"
+      - "9090:9090/tcp@host"
+`
+
+	project, err := loadProjectFromContent(t, content)
+	require.NoError(t, err)
+
+	service, err := project.GetService("web")
+	require.NoError(t, err)
+
+	specs, ok := service.Extensions[PortsExtensionKey].([]api.PortSpec)
+	require.True(t, ok, "Service should have port specs")
+	
+	// Just verify that x-ports still work - don't check exact values as that's tested elsewhere
+	assert.Len(t, specs, 3)
+}
+

--- a/pkg/client/compose/project.go
+++ b/pkg/client/compose/project.go
@@ -5,7 +5,7 @@ package compose
 import (
 	"context"
 	"fmt"
-	
+
 	composecli "github.com/compose-spec/compose-go/v2/cli"
 	"github.com/compose-spec/compose-go/v2/types"
 )
@@ -27,7 +27,7 @@ func LoadProject(ctx context.Context, paths []string, opts ...composecli.Project
 		composecli.WithExtension(PortsExtensionKey, PortsSource{}),
 		composecli.WithExtension(MachinesExtensionKey, MachinesSource{}),
 	}
-	
+
 	options, err := composecli.NewProjectOptions(
 		paths,
 		append(defaultOpts, opts...)...,
@@ -35,15 +35,15 @@ func LoadProject(ctx context.Context, paths []string, opts ...composecli.Project
 	if err != nil {
 		return nil, fmt.Errorf("create compose parser options: %w", err)
 	}
-	
+
 	project, err := options.LoadProject(ctx)
 	if err != nil {
 		return nil, err
 	}
-	
+
 	if project, err = transformServicesPortsExtension(project); err != nil {
 		return nil, err
 	}
-	
+
 	return project, nil
 }


### PR DESCRIPTION
The implementation works as an alias/wrapper around the existing `x-ports` functionality, allowing users to use familiar compose syntax while leveraging Uncloud's port forwarding capabilities.

 Changes
  -  Services can specify either `ports` or `x-ports`, but not both
  -  Standard compose ports are converted to x-ports string format
  -  Existing x-ports functionality remains unchanged, but mutual exclusivity


Examples:
```yaml
  services:
    web:
      image: nginx
      ports:
        - "80:8080"
        - "443:8443/tcp"

  Long Syntax with Host Mode

  services:
    api:
      image: api
      ports:
        - target: 8080
          published: 80
          protocol: tcp
          mode: host
          host_ip: "127.0.0.1"

  IPv6 Support

  services:
    service:
      image: app
      ports:
        - "[::1]:6001:6001"

  Services cannot specify both ports and x-ports directives
This will result in an error
  services:
    web:
      image: nginx
      ports:
        - "80:8080"
      x-ports:
        - "443:8443/https"

```
Related issue: #81