### PR TITLE
E2E tests use repeated strings for test data where constants add no value

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -25,15 +25,15 @@ jobs:
         with:
           go-version: "1.23.2"
 
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9 # v8.0.0
+        with:
+          version: v2.2.2
+
       - name: Format code
         run: |
           make format
           git diff --exit-code ||
             (echo "Code is not formatted. Please run 'make format' and commit the changes." && exit 1)
-
-      - name: golangci-lint
-        uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9 # v8.0.0
-        with:
-          version: v2.2.2
 
     timeout-minutes: 10

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,4 +1,10 @@
 version: "2"
+
+run:
+  concurrency: 4
+  tests: true
+  timeout: 5m
+
 linters:
   default: none
   enable:
@@ -26,5 +32,12 @@ linters:
 
 formatters:
   enable:
-    - gofmt
-    # - goimports
+    - gofumpt
+    - goimports
+    - gci
+
+issues:
+  exclude-rules:
+    - path: "test/e2e"
+      linters:
+        - goconst  # constants here add no value, so we skip goconst only for test/e2e.

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -39,5 +39,4 @@ formatters:
   enable:
     - gofumpt
     - goimports
-    - gci
 

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -29,6 +29,11 @@ linters:
     # - unparam
     # - unused
     - whitespace
+  exclusions:
+    rules:
+      - path: ^test/e2e
+        linters:
+          - goconst  # constants here add no value, so we skip goconst only for test/e2e.
 
 formatters:
   enable:
@@ -36,8 +41,3 @@ formatters:
     - goimports
     - gci
 
-issues:
-  exclude-rules:
-    - path: "test/e2e"
-      linters:
-        - goconst  # constants here add no value, so we skip goconst only for test/e2e.

--- a/Makefile
+++ b/Makefile
@@ -103,10 +103,6 @@ _lint:
 	# Uncloud daemon won't likely support OS other than Linux anytime soon, so for now we can rely on that.
 	GOOS=linux golangci-lint run $(ARGS)
 
-# .PHONY: lint-and-fix
-# lint-and-fix: lint
-# 	ARGS="--fix"
-
 .PHONY: docs-image-push
 docs-image:
 	docker buildx build --push --platform linux/amd64,linux/arm64 -t "$(DOCS_IMAGE)" ./docs

--- a/Makefile
+++ b/Makefile
@@ -99,6 +99,8 @@ $(LINT_TARGETS): _lint
 lint: ARGS=
 lint-and-fix: ARGS=--fix
 _lint:
+	# Explicitly set OS to Linux to not skip *_linux.go files when running on macOS.
+	# Uncloud daemon won't likely support OS other than Linux anytime soon, so for now we can rely on that.
 	GOOS=linux golangci-lint run $(ARGS)
 
 # .PHONY: lint-and-fix

--- a/Makefile
+++ b/Makefile
@@ -104,5 +104,5 @@ _lint:
 	GOOS=linux golangci-lint run $(ARGS)
 
 .PHONY: docs-image-push
-docs-image:
+docs-image-push:
 	docker buildx build --push --platform linux/amd64,linux/arm64 -t "$(DOCS_IMAGE)" ./docs

--- a/Makefile
+++ b/Makefile
@@ -99,7 +99,7 @@ $(LINT_TARGETS): _lint
 lint: ARGS=
 lint-and-fix: ARGS=--fix
 _lint:
-	golangci-lint run $(ARGS)
+	GOOS=linux golangci-lint run $(ARGS)
 
 # .PHONY: lint-and-fix
 # lint-and-fix: lint

--- a/Makefile
+++ b/Makefile
@@ -89,9 +89,9 @@ test-clean:
 vet:
 	go vet ./...
 
-.PHONY: format
-format:
-	go fmt ./...
+.PHONY: format fmt
+format fmt:
+	GOOS=linux golangci-lint fmt
 
 LINT_TARGETS := lint lint-and-fix
 .PHONY: $(LINT_TARGETS) _lint

--- a/cmd/ucind/cluster/create.go
+++ b/cmd/ucind/cluster/create.go
@@ -2,6 +2,7 @@ package cluster
 
 import (
 	"fmt"
+
 	"github.com/psviderski/uncloud/internal/ucind"
 	"github.com/spf13/cobra"
 )

--- a/cmd/ucind/cluster/remove.go
+++ b/cmd/ucind/cluster/remove.go
@@ -2,6 +2,7 @@ package cluster
 
 import (
 	"fmt"
+
 	"github.com/psviderski/uncloud/internal/ucind"
 	"github.com/spf13/cobra"
 )

--- a/cmd/ucind/cluster/root.go
+++ b/cmd/ucind/cluster/root.go
@@ -13,7 +13,7 @@ func NewRootCommand() *cobra.Command {
 	}
 	cmd.AddCommand(
 		NewCreateCommand(),
-		//NewListCommand(),
+		// NewListCommand(),
 		NewRemoveCommand(),
 	)
 	return cmd

--- a/cmd/uncloud/machine/rm.go
+++ b/cmd/uncloud/machine/rm.go
@@ -101,7 +101,6 @@ func remove(ctx context.Context, uncli *cli.CLI, machineName string, opts remove
 		err = progress.RunWithTitle(ctx, func(ctx context.Context) error {
 			return removeContainers(ctx, client, containers)
 		}, uncli.ProgressOut(), "Removing containers")
-
 		if err != nil {
 			return fmt.Errorf("remove containers: %w", err)
 		}
@@ -112,8 +111,8 @@ func remove(ctx context.Context, uncli *cli.CLI, machineName string, opts remove
 	// TODO: 5. Remove the machine from the cluster store.
 
 	return fmt.Errorf("resetting machine is not fully implemented yet")
-	//fmt.Printf("Machine '%s' removed from the cluster.\n", m.Name)
-	//return nil
+	// fmt.Printf("Machine '%s' removed from the cluster.\n", m.Name)
+	// return nil
 }
 
 // formatContainerTree formats a list of containers grouped by service as a tree structure.

--- a/cmd/uncloud/machine/token.go
+++ b/cmd/uncloud/machine/token.go
@@ -2,6 +2,7 @@ package machine
 
 import (
 	"fmt"
+
 	"github.com/psviderski/uncloud/internal/daemon"
 	"github.com/psviderski/uncloud/internal/machine"
 	"github.com/spf13/cobra"

--- a/cmd/uncloud/service/inspect.go
+++ b/cmd/uncloud/service/inspect.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/docker/docker/pkg/stringid"
 	"github.com/docker/go-units"
-
 	"github.com/psviderski/uncloud/internal/cli"
 	"github.com/spf13/cobra"
 )

--- a/experiment/broadcaster.go
+++ b/experiment/broadcaster.go
@@ -3,10 +3,11 @@ package main
 import (
 	"context"
 	"fmt"
-	"github.com/hashicorp/serf/serf"
-	crdt "github.com/ipfs/go-ds-crdt"
 	"log/slog"
 	"time"
+
+	"github.com/hashicorp/serf/serf"
+	crdt "github.com/ipfs/go-ds-crdt"
 )
 
 // Implements the Broadcaster interface.

--- a/experiment/explorer/explorer.go
+++ b/experiment/explorer/explorer.go
@@ -2,9 +2,10 @@ package main
 
 import (
 	"fmt"
-	"github.com/dgraph-io/badger/v3"
 	"log"
 	"time"
+
+	"github.com/dgraph-io/badger/v3"
 )
 
 func customTimeEncoder(t time.Time) string {

--- a/experiment/logger.go
+++ b/experiment/logger.go
@@ -2,9 +2,10 @@ package main
 
 import (
 	"fmt"
-	"github.com/ipfs/go-log/v2"
 	"log/slog"
 	"os"
+
+	"github.com/ipfs/go-log/v2"
 )
 
 // ipfsLogger is an slog logger that implements the IPFS go-log StandardLogger interface.

--- a/experiment/networkdb/main.go
+++ b/experiment/networkdb/main.go
@@ -2,12 +2,13 @@ package main
 
 import (
 	"fmt"
-	"github.com/docker/docker/libnetwork/networkdb"
 	"log/slog"
 	"os"
 	"os/signal"
 	"syscall"
 	"time"
+
+	"github.com/docker/docker/libnetwork/networkdb"
 )
 
 func main() {

--- a/experiment/serf_crdt.go
+++ b/experiment/serf_crdt.go
@@ -4,6 +4,13 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	"log/slog"
+	"net"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
 	"github.com/hashicorp/memberlist"
 	"github.com/hashicorp/serf/cmd/serf/command/agent"
 	"github.com/hashicorp/serf/serf"
@@ -11,12 +18,6 @@ import (
 	badger "github.com/ipfs/go-ds-badger3"
 	crdt "github.com/ipfs/go-ds-crdt"
 	"github.com/lmittmann/tint"
-	"log/slog"
-	"net"
-	"os"
-	"os/signal"
-	"syscall"
-	"time"
 )
 
 func createSerfAgentConfig(name, bindAddr, rpcAddr, profile string) *agent.Config {
@@ -49,9 +50,9 @@ func createSerfAgent(config *agent.Config) (*agent.Agent, error) {
 
 	serfConfig.MemberlistConfig.BindAddr = bindIP
 	serfConfig.MemberlistConfig.BindPort = bindPort
-	//serfConfig.MemberlistConfig.AdvertiseAddr = advertiseIP
-	//serfConfig.MemberlistConfig.AdvertisePort = advertisePort
-	//serfConfig.MemberlistConfig.SecretKey = encryptKey
+	// serfConfig.MemberlistConfig.AdvertiseAddr = advertiseIP
+	// serfConfig.MemberlistConfig.AdvertisePort = advertisePort
+	// serfConfig.MemberlistConfig.SecretKey = encryptKey
 	serfConfig.NodeName = config.NodeName
 	serfConfig.Tags = config.Tags
 	serfConfig.SnapshotPath = config.SnapshotPath
@@ -129,7 +130,7 @@ func main() {
 	logger := slog.New(tint.NewHandler(os.Stdout, &tint.Options{
 		AddSource: true,
 		Level:     slog.LevelDebug,
-		//Level:      slog.LevelInfo,
+		// Level:      slog.LevelInfo,
 		TimeFormat: time.RFC3339Nano,
 	}))
 	slog.SetDefault(logger)
@@ -164,7 +165,7 @@ func main() {
 
 	opts := crdt.DefaultOptions()
 	opts.Logger = newIPFSLogger(logger)
-	//opts.MultiHeadProcessing = true
+	// opts.MultiHeadProcessing = true
 	// TODO: debug why the heads count may grow on the receiving side if the event backlog is huge and the processing
 	//  is slow.
 	store, err := crdt.New(localStore, ds.NewKey("/"), syncer, broadcaster, opts)
@@ -172,7 +173,7 @@ func main() {
 		panic(err)
 	}
 
-	//ticker := time.NewTicker(10 * time.Millisecond)
+	// ticker := time.NewTicker(10 * time.Millisecond)
 	ticker := time.NewTicker(3 * time.Second)
 	go func() {
 		for {

--- a/experiment/talos_discovery.go
+++ b/experiment/talos_discovery.go
@@ -6,12 +6,13 @@ import (
 	"crypto/cipher"
 	"encoding/hex"
 	"fmt"
+	"net/netip"
+	"time"
+
 	"github.com/psviderski/uncloud/internal/machine/network"
 	"github.com/siderolabs/discovery-api/api/v1alpha1/client/pb"
 	discovery "github.com/siderolabs/discovery-client/pkg/client"
 	"go.uber.org/zap"
-	"net/netip"
-	"time"
 )
 
 const (

--- a/internal/cli/config/config.go
+++ b/internal/cli/config/config.go
@@ -53,11 +53,11 @@ func (c *Config) Read() error {
 
 func (c *Config) Save() error {
 	dir, _ := filepath.Split(c.path)
-	if err := os.MkdirAll(dir, 0700); err != nil {
+	if err := os.MkdirAll(dir, 0o700); err != nil {
 		return fmt.Errorf("create config directory '%s': %w", dir, err)
 	}
 
-	f, err := os.OpenFile(c.path, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0600)
+	f, err := os.OpenFile(c.path, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o600)
 	if err != nil {
 		return fmt.Errorf("write config file '%s': %w", c.path, err)
 	}

--- a/internal/corrosion/client.go
+++ b/internal/corrosion/client.go
@@ -5,14 +5,15 @@ import (
 	"crypto/tls"
 	"errors"
 	"fmt"
-	"github.com/cenkalti/backoff/v4"
-	"golang.org/x/net/http2"
 	"log/slog"
 	"net"
 	"net/http"
 	"net/netip"
 	"net/url"
 	"time"
+
+	"github.com/cenkalti/backoff/v4"
+	"golang.org/x/net/http2"
 )
 
 const (

--- a/internal/corrosion/subscribe.go
+++ b/internal/corrosion/subscribe.go
@@ -6,11 +6,12 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/cenkalti/backoff/v4"
 	"io"
 	"log/slog"
 	"net/http"
 	"strconv"
+
+	"github.com/cenkalti/backoff/v4"
 )
 
 type ChangeType string

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -3,9 +3,10 @@ package daemon
 import (
 	"context"
 	"fmt"
+	"log/slog"
+
 	systemd "github.com/coreos/go-systemd/daemon"
 	"github.com/psviderski/uncloud/internal/machine"
-	"log/slog"
 )
 
 type Daemon struct {

--- a/internal/daemon/token.go
+++ b/internal/daemon/token.go
@@ -3,10 +3,11 @@ package daemon
 import (
 	"errors"
 	"fmt"
-	"github.com/psviderski/uncloud/internal/machine"
-	"github.com/psviderski/uncloud/internal/machine/network"
 	"net/netip"
 	"os"
+
+	"github.com/psviderski/uncloud/internal/machine"
+	"github.com/psviderski/uncloud/internal/machine/network"
 )
 
 // MachineToken returns the local machine's token that can be used for adding the machine to a cluster.

--- a/internal/docker/client.go
+++ b/internal/docker/client.go
@@ -4,10 +4,11 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/cenkalti/backoff/v4"
-	"github.com/docker/docker/client"
 	"log/slog"
 	"time"
+
+	"github.com/cenkalti/backoff/v4"
+	"github.com/docker/docker/client"
 )
 
 // WaitDaemonReady waits for the Docker daemon to start and be ready to serve requests.

--- a/internal/machine/api/proxy/backend.go
+++ b/internal/machine/api/proxy/backend.go
@@ -2,6 +2,7 @@ package proxy
 
 import (
 	"fmt"
+
 	"github.com/psviderski/uncloud/internal/machine/api/pb"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/encoding/protowire"

--- a/internal/machine/api/proxy/director.go
+++ b/internal/machine/api/proxy/director.go
@@ -2,11 +2,12 @@ package proxy
 
 import (
 	"context"
+	"sync"
+
 	"github.com/siderolabs/grpc-proxy/proxy"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
-	"sync"
 )
 
 // Director manages routing of gRPC requests between local and remote backends.

--- a/internal/machine/api/proxy/local.go
+++ b/internal/machine/api/proxy/local.go
@@ -2,11 +2,12 @@ package proxy
 
 import (
 	"context"
+	"sync"
+
 	"github.com/siderolabs/grpc-proxy/proxy"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/metadata"
-	"sync"
 )
 
 // LocalBackend is a proxy.One2ManyResponder implementation that proxies to a local gRPC server listening on a Unix socket.

--- a/internal/machine/api/proxy/remote.go
+++ b/internal/machine/api/proxy/remote.go
@@ -3,14 +3,15 @@ package proxy
 import (
 	"context"
 	"fmt"
+	"net/netip"
+	"sync"
+	"time"
+
 	"github.com/siderolabs/grpc-proxy/proxy"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/backoff"
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/metadata"
-	"net/netip"
-	"sync"
-	"time"
 )
 
 // RemoteBackend is a proxy.One2ManyResponder implementation that proxies to a remote gRPC server, injecting machine metadata

--- a/internal/machine/caddyconfig/controller.go
+++ b/internal/machine/caddyconfig/controller.go
@@ -29,7 +29,7 @@ type Controller struct {
 
 func NewController(store *store.Store, path string, verifyResponse string) (*Controller, error) {
 	dir := filepath.Dir(path)
-	if err := os.MkdirAll(dir, 0750); err != nil {
+	if err := os.MkdirAll(dir, 0o750); err != nil {
 		return nil, fmt.Errorf("create parent directory for Caddy configuration '%s': %w", dir, err)
 	}
 	if err := fs.Chown(dir, "", CaddyGroup); err != nil {
@@ -114,7 +114,7 @@ func (c *Controller) generateConfig(containers []api.ServiceContainer) error {
 		return fmt.Errorf("marshal Caddy configuration: %w", err)
 	}
 
-	if err = os.WriteFile(c.path, configBytes, 0640); err != nil {
+	if err = os.WriteFile(c.path, configBytes, 0o640); err != nil {
 		return fmt.Errorf("write Caddy configuration to file '%s': %w", c.path, err)
 	}
 	if err = fs.Chown(c.path, "", CaddyGroup); err != nil {

--- a/internal/machine/cluster/cluster.go
+++ b/internal/machine/cluster/cluster.go
@@ -5,6 +5,10 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
+	"net/netip"
+	"time"
+
 	"github.com/psviderski/uncloud/internal/corrosion"
 	"github.com/psviderski/uncloud/internal/machine/api/pb"
 	"github.com/psviderski/uncloud/internal/machine/network"
@@ -13,9 +17,6 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/emptypb"
-	"log/slog"
-	"net/netip"
-	"time"
 )
 
 type Cluster struct {

--- a/internal/machine/cluster/dns.go
+++ b/internal/machine/cluster/dns.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+
 	"github.com/psviderski/uncloud/internal/dns"
 	"github.com/psviderski/uncloud/internal/machine/api/pb"
 	"github.com/psviderski/uncloud/internal/machine/store"

--- a/internal/machine/cluster/ipam.go
+++ b/internal/machine/cluster/ipam.go
@@ -3,8 +3,9 @@ package cluster
 import (
 	"errors"
 	"fmt"
-	"go4.org/netipx"
 	"net/netip"
+
+	"go4.org/netipx"
 )
 
 const DefaultSubnetBits = 24

--- a/internal/machine/cluster/machine.go
+++ b/internal/machine/cluster/machine.go
@@ -2,6 +2,7 @@ package cluster
 
 import (
 	"fmt"
+
 	"github.com/psviderski/uncloud/internal/secret"
 )
 

--- a/internal/machine/corroservice/config.go
+++ b/internal/machine/corroservice/config.go
@@ -3,11 +3,12 @@ package corroservice
 import (
 	"bytes"
 	"fmt"
-	"github.com/BurntSushi/toml"
-	"github.com/psviderski/uncloud/internal/fs"
 	"net/netip"
 	"os"
 	"path/filepath"
+
+	"github.com/BurntSushi/toml"
+	"github.com/psviderski/uncloud/internal/fs"
 )
 
 const (
@@ -50,7 +51,7 @@ func (c *Config) Write(path, owner string) error {
 	if err := encoder.Encode(c); err != nil {
 		return fmt.Errorf("encode config: %w", err)
 	}
-	if err := os.WriteFile(path, data.Bytes(), 0600); err != nil {
+	if err := os.WriteFile(path, data.Bytes(), 0o600); err != nil {
 		return err
 	}
 	if err := fs.Chown(path, owner, owner); err != nil {
@@ -62,10 +63,10 @@ func (c *Config) Write(path, owner string) error {
 func MkDataDir(dir, owner string) error {
 	parent, _ := filepath.Split(dir)
 	// Use 0711 for parent directories to allow `owner` to access its nested data directory.
-	if err := os.MkdirAll(parent, 0711); err != nil {
+	if err := os.MkdirAll(parent, 0o711); err != nil {
 		return fmt.Errorf("create directory %q: %w", parent, err)
 	}
-	if err := os.Mkdir(dir, 0700); err != nil {
+	if err := os.Mkdir(dir, 0o700); err != nil {
 		if !os.IsExist(err) {
 			return fmt.Errorf("create directory %q: %w", dir, err)
 		}

--- a/internal/machine/corroservice/docker.go
+++ b/internal/machine/corroservice/docker.go
@@ -3,15 +3,16 @@ package corroservice
 import (
 	"context"
 	"fmt"
+	"io"
+	"log/slog"
+	"path/filepath"
+	"time"
+
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/image"
 	"github.com/docker/docker/api/types/mount"
 	"github.com/docker/docker/api/types/network"
 	"github.com/docker/docker/client"
-	"io"
-	"log/slog"
-	"path/filepath"
-	"time"
 )
 
 const (

--- a/internal/machine/corroservice/subprocess.go
+++ b/internal/machine/corroservice/subprocess.go
@@ -111,8 +111,8 @@ func (s *SubprocessService) startProcess(ctx context.Context) error {
 
 	// TODO: figure out the waiting process
 	// Wait for initialization
-	//timer := time.NewTimer(2 * time.Second)
-	//defer timer.Stop()
+	// timer := time.NewTimer(2 * time.Second)
+	// defer timer.Stop()
 
 	//select {
 	////case <-timer.C:

--- a/internal/machine/db.go
+++ b/internal/machine/db.go
@@ -14,13 +14,13 @@ const DBFileName = "machine.db"
 func NewDB(path string) (*sqlx.DB, error) {
 	// Create the database file with 0600 permissions if it doesn't exist, or update permissions if exists.
 	if _, err := os.Stat(path); os.IsNotExist(err) {
-		file, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR, 0600)
+		file, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR, 0o600)
 		if err != nil {
 			return nil, fmt.Errorf("create SQLite database '%s': %w", path, err)
 		}
 		file.Close()
 	} else {
-		if err = os.Chmod(path, 0600); err != nil {
+		if err = os.Chmod(path, 0o600); err != nil {
 			return nil, fmt.Errorf("update SQLite database permissions '%s': %w", path, err)
 		}
 	}

--- a/internal/machine/machine.go
+++ b/internal/machine/machine.go
@@ -501,7 +501,7 @@ func listenUnixSocket(path string) (net.Listener, error) {
 
 	// Ensure the parent directory exists and has the correct group permissions.
 	parent, _ := filepath.Split(path)
-	if err = os.MkdirAll(parent, 0750); err != nil {
+	if err = os.MkdirAll(parent, 0o750); err != nil {
 		return nil, fmt.Errorf("create directory %q: %w", parent, err)
 	}
 	if err = os.Chown(parent, -1, gid); err != nil {
@@ -555,7 +555,7 @@ func (m *Machine) configureCorrosion() error {
 		return fmt.Errorf("write corrosion config: %w", err)
 	}
 
-	if err := os.WriteFile(schemaPath, []byte(store.Schema), 0644); err != nil {
+	if err := os.WriteFile(schemaPath, []byte(store.Schema), 0o644); err != nil {
 		return fmt.Errorf("write corrosion schema: %w", err)
 	}
 

--- a/internal/machine/network/peer.go
+++ b/internal/machine/network/peer.go
@@ -1,11 +1,12 @@
 package network
 
 import (
-	"golang.zx2c4.com/wireguard/wgctrl/wgtypes"
 	"log/slog"
 	"net/netip"
 	"slices"
 	"time"
+
+	"golang.zx2c4.com/wireguard/wgctrl/wgtypes"
 )
 
 const (

--- a/internal/machine/network/tunnel/tunnel.go
+++ b/internal/machine/network/tunnel/tunnel.go
@@ -3,13 +3,14 @@ package tunnel
 import (
 	"context"
 	"fmt"
+	"net"
+	"net/netip"
+	"time"
+
 	"github.com/psviderski/uncloud/internal/secret"
 	"golang.zx2c4.com/wireguard/conn"
 	"golang.zx2c4.com/wireguard/device"
 	"golang.zx2c4.com/wireguard/tun/netstack"
-	"net"
-	"net/netip"
-	"time"
 )
 
 const (

--- a/internal/machine/network/wireguard.go
+++ b/internal/machine/network/wireguard.go
@@ -2,10 +2,11 @@ package network
 
 import (
 	"fmt"
-	"github.com/psviderski/uncloud/internal/secret"
-	"golang.zx2c4.com/wireguard/wgctrl/wgtypes"
 	"net/netip"
 	"time"
+
+	"github.com/psviderski/uncloud/internal/secret"
+	"golang.zx2c4.com/wireguard/wgctrl/wgtypes"
 )
 
 const (

--- a/internal/machine/network/wireguard_linux.go
+++ b/internal/machine/network/wireguard_linux.go
@@ -6,18 +6,20 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/psviderski/uncloud/internal/secret"
-	"github.com/vishvananda/netlink"
-	"go4.org/netipx"
-	"golang.org/x/sys/unix"
-	"golang.zx2c4.com/wireguard/wgctrl"
-	"golang.zx2c4.com/wireguard/wgctrl/wgtypes"
 	"log/slog"
 	"net"
 	"net/netip"
 	"slices"
 	"sync"
 	"time"
+
+	"github.com/vishvananda/netlink"
+	"go4.org/netipx"
+	"golang.org/x/sys/unix"
+	"golang.zx2c4.com/wireguard/wgctrl"
+	"golang.zx2c4.com/wireguard/wgctrl/wgtypes"
+
+	"github.com/psviderski/uncloud/internal/secret"
 )
 
 type WireGuardNetwork struct {

--- a/internal/machine/network/wireguard_linux.go
+++ b/internal/machine/network/wireguard_linux.go
@@ -13,13 +13,12 @@ import (
 	"sync"
 	"time"
 
+	"github.com/psviderski/uncloud/internal/secret"
 	"github.com/vishvananda/netlink"
 	"go4.org/netipx"
 	"golang.org/x/sys/unix"
 	"golang.zx2c4.com/wireguard/wgctrl"
 	"golang.zx2c4.com/wireguard/wgctrl/wgtypes"
-
-	"github.com/psviderski/uncloud/internal/secret"
 )
 
 type WireGuardNetwork struct {

--- a/internal/machine/state.go
+++ b/internal/machine/state.go
@@ -3,10 +3,11 @@ package machine
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/psviderski/uncloud/internal/machine/network"
 	"os"
 	"path/filepath"
 	"sync"
+
+	"github.com/psviderski/uncloud/internal/machine/network"
 )
 
 const (
@@ -71,7 +72,7 @@ func (c *State) Save() error {
 		return fmt.Errorf("state path not set")
 	}
 	dir, _ := filepath.Split(c.path)
-	if err := os.MkdirAll(dir, 0711); err != nil {
+	if err := os.MkdirAll(dir, 0o711); err != nil {
 		return fmt.Errorf("create state directory %q: %w", dir, err)
 	}
 
@@ -79,5 +80,5 @@ func (c *State) Save() error {
 	if err != nil {
 		return err
 	}
-	return os.WriteFile(c.path, data, 0600)
+	return os.WriteFile(c.path, data, 0o600)
 }

--- a/internal/machine/store/container.go
+++ b/internal/machine/store/container.go
@@ -4,11 +4,12 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	sq "github.com/Masterminds/squirrel"
-	"github.com/psviderski/uncloud/pkg/api"
 	"log/slog"
 	"strings"
 	"time"
+
+	sq "github.com/Masterminds/squirrel"
+	"github.com/psviderski/uncloud/pkg/api"
 )
 
 const (

--- a/internal/machine/store/store.go
+++ b/internal/machine/store/store.go
@@ -5,10 +5,11 @@ import (
 	_ "embed"
 	"errors"
 	"fmt"
+	"log/slog"
+
 	"github.com/psviderski/uncloud/internal/corrosion"
 	"github.com/psviderski/uncloud/internal/machine/api/pb"
 	"google.golang.org/protobuf/encoding/protojson"
-	"log/slog"
 )
 
 var (

--- a/internal/machine/token.go
+++ b/internal/machine/token.go
@@ -4,9 +4,10 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"github.com/psviderski/uncloud/internal/secret"
 	"net/netip"
 	"strings"
+
+	"github.com/psviderski/uncloud/internal/secret"
 )
 
 const (

--- a/internal/sshexec/remote.go
+++ b/internal/sshexec/remote.go
@@ -3,9 +3,10 @@ package sshexec
 import (
 	"context"
 	"fmt"
-	"golang.org/x/crypto/ssh"
 	"io"
 	"strings"
+
+	"golang.org/x/crypto/ssh"
 )
 
 type Remote struct {

--- a/internal/ucind/provision.go
+++ b/internal/ucind/provision.go
@@ -2,6 +2,7 @@ package ucind
 
 import (
 	"errors"
+
 	"github.com/docker/docker/client"
 )
 

--- a/pkg/api/port.go
+++ b/pkg/api/port.go
@@ -34,23 +34,6 @@ type PortSpec struct {
 	Mode string
 }
 
-func (p *PortSpec) isHTTP() bool {
-	return p.Protocol == ProtocolHTTP || p.Protocol == ProtocolHTTPS
-}
-
-// AdjustUncloudMode makes adjustments for uncloud compatibility
-func (p *PortSpec) AdjustUncloudMode() {
-	if p.Protocol == "" {
-		p.Protocol = "tcp"
-	}
-	if p.Mode == "" {
-		p.Mode = PortModeIngress
-	}
-	if p.Mode == PortModeIngress && !p.isHTTP() && p.PublishedPort != 0 {
-		p.Mode = PortModeHost
-	}
-}
-
 func (p *PortSpec) Validate() error {
 	if p.ContainerPort == 0 {
 		return fmt.Errorf("container port must be non-zero")
@@ -73,7 +56,7 @@ func (p *PortSpec) Validate() error {
 			return fmt.Errorf("host IP cannot be specified in %s mode", PortModeIngress)
 		}
 		if p.Hostname != "" {
-			if !p.isHTTP() {
+			if p.Protocol != ProtocolHTTP && p.Protocol != ProtocolHTTPS {
 				return fmt.Errorf("hostname is only valid with '%s' or '%s' protocols", ProtocolHTTP, ProtocolHTTPS)
 			}
 			if err := validateHostname(p.Hostname); err != nil {

--- a/pkg/api/port_test.go
+++ b/pkg/api/port_test.go
@@ -1,10 +1,11 @@
 package api
 
 import (
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"net/netip"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestPortSpec_Validate(t *testing.T) {

--- a/pkg/client/caddy_test.go
+++ b/pkg/client/caddy_test.go
@@ -1,10 +1,11 @@
 package client
 
 import (
+	"testing"
+
 	"github.com/distribution/reference"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"testing"
 )
 
 func TestLatestCaddyImage(t *testing.T) {

--- a/pkg/client/compose/port.go
+++ b/pkg/client/compose/port.go
@@ -5,26 +5,59 @@ import (
 
 	"github.com/compose-spec/compose-go/v2/types"
 	"github.com/psviderski/uncloud/pkg/api"
+	"net/netip"
+	"strconv"
 )
 
 const PortsExtensionKey = "x-ports"
 
 type PortsSource []string
 
-// TransformServicesPortsExtension transforms the ports extension of all services in the project by replacing a string
-// representation of each port with a parsed PortSpec.
+// transformServicesPortsExtension transforms both standard 'ports' and 'x-ports' to PortSpecs.
 func transformServicesPortsExtension(project *types.Project) (*types.Project, error) {
 	return project.WithServicesTransform(func(name string, service types.ServiceConfig) (types.ServiceConfig, error) {
-		ports, ok := service.Extensions[PortsExtensionKey].(PortsSource)
-		if !ok {
+		// Check for mutual exclusivity
+		hasStandardPorts := len(service.Ports) > 0
+		hasXPorts := service.Extensions[PortsExtensionKey] != nil
+
+		if hasStandardPorts && hasXPorts {
+			return service, fmt.Errorf("service %q cannot specify both 'ports' and 'x-ports' directives, use only one", name)
+		}
+
+		var (
+			specs []api.PortSpec
+			err   error
+		)
+
+		if hasStandardPorts {
+			// Convert standard ports directly to api.PortSpec
+			specs, err = convertStandardPortsToPortSpecs(service.Ports)
+			if err != nil {
+				return service, fmt.Errorf("convert standard ports for service %q: %w", name, err)
+			}
+		} else if hasXPorts {
+			// Use existing x-ports string-based processing for backward compatibility
+			var portsSource PortsSource
+			var ok bool
+			portsSource, ok = service.Extensions[PortsExtensionKey].(PortsSource)
+			if !ok {
+				return service, nil
+			}
+
+			// Parse the port strings using existing logic
+			specs, err = transformPortsExtension(portsSource)
+			if err != nil {
+				return service, err
+			}
+		} else {
+			// No ports specified
 			return service, nil
 		}
 
-		specs, err := transformPortsExtension(ports)
-		if err != nil {
-			return service, err
+		// Ensure extensions map exists before setting the port specs
+		if service.Extensions == nil {
+			service.Extensions = make(types.Extensions)
 		}
-
 		service.Extensions[PortsExtensionKey] = specs
 		return service, nil
 	})
@@ -36,6 +69,57 @@ func transformPortsExtension(ports PortsSource) ([]api.PortSpec, error) {
 		spec, err := api.ParsePortSpec(port)
 		if err != nil {
 			return specs, fmt.Errorf("parse port %q: %w", port, err)
+		}
+		specs = append(specs, spec)
+	}
+
+	return specs, nil
+}
+
+// convertServicePortConfigToPortSpec converts types.ServicePortConfig directly to api.PortSpec
+func convertServicePortConfigToPortSpec(port types.ServicePortConfig) (api.PortSpec, error) {
+	spec := api.PortSpec{
+		ContainerPort: uint16(port.Target),
+		Protocol:      port.Protocol,
+		Mode:          port.Mode,
+	}
+	// Set published port if specified
+	if port.Published != "" {
+		publishedPort, err := strconv.ParseUint(port.Published, 10, 16)
+		if err != nil {
+			return spec, fmt.Errorf("invalid published port %q: %w", port.Published, err)
+		}
+		spec.PublishedPort = uint16(publishedPort)
+	}
+
+	// Set host IP if specified
+	if port.HostIP != "" {
+		hostIP, err := netip.ParseAddr(port.HostIP)
+		if err != nil {
+			return spec, fmt.Errorf("invalid host IP %q: %w", port.HostIP, err)
+		}
+		spec.HostIP = hostIP
+	}
+
+	// Apply defaults according to uncloud
+	spec.AdjustUncloudMode()
+
+	// Validate the resulting spec
+	if err := spec.Validate(); err != nil {
+		return spec, fmt.Errorf("invalid port configuration: %w", err)
+	}
+
+	return spec, nil
+}
+
+// convertStandardPortsToPortSpecs converts []types.ServicePortConfig directly to api.PortSpecs.
+func convertStandardPortsToPortSpecs(ports []types.ServicePortConfig) ([]api.PortSpec, error) {
+	var specs = make([]api.PortSpec, 0, len(ports))
+
+	for _, port := range ports {
+		spec, err := convertServicePortConfigToPortSpec(port)
+		if err != nil {
+			return nil, err
 		}
 		specs = append(specs, spec)
 	}

--- a/pkg/client/compose/port.go
+++ b/pkg/client/compose/port.go
@@ -2,9 +2,6 @@ package compose
 
 import (
 	"fmt"
-
-	"github.com/compose-spec/compose-go/v2/types"
-	"github.com/psviderski/uncloud/pkg/api"
 	"net/netip"
 	"strconv"
 	"strings"
@@ -131,7 +128,7 @@ func convertServicePortConfigToPortSpec(port types.ServicePortConfig) (api.PortS
 
 // convertStandardPortsToPortSpecs converts []types.ServicePortConfig directly to api.PortSpecs.
 func convertStandardPortsToPortSpecs(ports []types.ServicePortConfig) ([]api.PortSpec, error) {
-	var specs = make([]api.PortSpec, 0, len(ports))
+	specs := make([]api.PortSpec, 0, len(ports))
 
 	for _, port := range ports {
 		spec, err := convertServicePortConfigToPortSpec(port)

--- a/pkg/client/compose/port.go
+++ b/pkg/client/compose/port.go
@@ -2,6 +2,7 @@ package compose
 
 import (
 	"fmt"
+
 	"github.com/compose-spec/compose-go/v2/types"
 	"github.com/psviderski/uncloud/pkg/api"
 )

--- a/pkg/client/compose/port_test.go
+++ b/pkg/client/compose/port_test.go
@@ -1,0 +1,408 @@
+package compose
+
+import (
+	"net/netip"
+	"testing"
+
+	"github.com/compose-spec/compose-go/v2/types"
+	"github.com/psviderski/uncloud/pkg/api"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConvertStandardPortsToPortSpecs(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		ports    []types.ServicePortConfig
+		expected []api.PortSpec
+		wantErr  string
+	}{
+		{
+			name: "multiple ports",
+			ports: []types.ServicePortConfig{
+				{Target: 8080, Published: "80", Protocol: "tcp"},
+				{Target: 8443, Published: "443", Protocol: "tcp", Mode: "host"},
+				{Target: 5353, Published: "53", Protocol: "udp"},
+			},
+			expected: []api.PortSpec{
+				{ContainerPort: 8080, PublishedPort: 80, Protocol: "tcp", Mode: "host"},
+				{ContainerPort: 8443, PublishedPort: 443, Protocol: "tcp", Mode: "host"},
+				{ContainerPort: 5353, PublishedPort: 53, Protocol: "udp", Mode: "host"},
+			},
+		},
+		{
+			name:     "empty ports",
+			ports:    []types.ServicePortConfig{},
+			expected: make([]api.PortSpec, 0),
+		},
+		{
+			name: "single port no published",
+			ports: []types.ServicePortConfig{
+				{Target: 8080},
+			},
+			expected: []api.PortSpec{
+				{ContainerPort: 8080, PublishedPort: 0, Protocol: "tcp", Mode: "ingress"},
+			},
+		},
+		{
+			name: "IPv6 host IP",
+			ports: []types.ServicePortConfig{
+				{Target: 8080, Published: "80", Protocol: "tcp", HostIP: "::1", Mode: "host"},
+			},
+			expected: []api.PortSpec{
+				{ContainerPort: 8080, PublishedPort: 80, Protocol: "tcp", Mode: "host", HostIP: mustParseAddr("::1")},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			result, err := convertStandardPortsToPortSpecs(tt.ports)
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+// mustParseAddr is a helper function for tests
+func mustParseAddr(s string) netip.Addr {
+	addr, err := netip.ParseAddr(s)
+	if err != nil {
+		panic(err)
+	}
+	return addr
+}
+
+func TestConvertServicePortConfigToPortSpec(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		port     types.ServicePortConfig
+		expected api.PortSpec
+		wantErr  string
+	}{
+		{
+			name: "basic port",
+			port: types.ServicePortConfig{
+				Target:    8080,
+				Published: "80",
+				Protocol:  "tcp",
+			},
+			expected: api.PortSpec{
+				ContainerPort: 8080,
+				PublishedPort: 80,
+				Protocol:      "tcp",
+				Mode:          "host",
+			},
+		},
+		{
+			name: "port with defaults",
+			port: types.ServicePortConfig{
+				Target: 8080,
+			},
+			expected: api.PortSpec{
+				ContainerPort: 8080,
+				PublishedPort: 0,
+				Protocol:      "tcp",
+				Mode:          "ingress",
+			},
+		},
+		{
+			name: "host mode with IP",
+			port: types.ServicePortConfig{
+				Target:    8080,
+				Published: "80",
+				Protocol:  "tcp",
+				Mode:      "host",
+				HostIP:    "127.0.0.1",
+			},
+			expected: api.PortSpec{
+				ContainerPort: 8080,
+				PublishedPort: 80,
+				Protocol:      "tcp",
+				Mode:          "host",
+				HostIP:        mustParseAddr("127.0.0.1"),
+			},
+		},
+		{
+			name: "UDP protocol",
+			port: types.ServicePortConfig{
+				Target:    5353,
+				Published: "53",
+				Protocol:  "udp",
+			},
+			expected: api.PortSpec{
+				ContainerPort: 5353,
+				PublishedPort: 53,
+				Protocol:      "udp",
+				Mode:          "host",
+			},
+		},
+		{
+			name: "IPv6 host IP",
+			port: types.ServicePortConfig{
+				Target:    8080,
+				Published: "80",
+				Protocol:  "tcp",
+				Mode:      "host",
+				HostIP:    "::1",
+			},
+			expected: api.PortSpec{
+				ContainerPort: 8080,
+				PublishedPort: 80,
+				Protocol:      "tcp",
+				Mode:          "host",
+				HostIP:        mustParseAddr("::1"),
+			},
+		},
+		{
+			name: "HTTP protocol stays in ingress mode",
+			port: types.ServicePortConfig{
+				Target:    8080,
+				Published: "80",
+				Protocol:  "http",
+			},
+			expected: api.PortSpec{
+				ContainerPort: 8080,
+				PublishedPort: 80,
+				Protocol:      "http",
+				Mode:          "ingress",
+			},
+		},
+		{
+			name: "HTTPS protocol stays in ingress mode",
+			port: types.ServicePortConfig{
+				Target:    8080,
+				Published: "443",
+				Protocol:  "https",
+			},
+			expected: api.PortSpec{
+				ContainerPort: 8080,
+				PublishedPort: 443,
+				Protocol:      "https",
+				Mode:          "ingress",
+			},
+		},
+		// Error cases
+		{
+			name: "invalid published port",
+			port: types.ServicePortConfig{
+				Target:    8080,
+				Published: "invalid",
+			},
+			wantErr: "invalid published port",
+		},
+		{
+			name: "invalid host IP",
+			port: types.ServicePortConfig{
+				Target:    8080,
+				Published: "80",
+				HostIP:    "invalid",
+			},
+			wantErr: "invalid host IP",
+		},
+		{
+			name: "missing container port",
+			port: types.ServicePortConfig{
+				Published: "80",
+			},
+			wantErr: "container port must be non-zero",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			result, err := convertServicePortConfigToPortSpec(tt.port)
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestTransformServicesPortsExtension_MutualExclusivity(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		content string
+		wantErr string
+	}{
+		{
+			name: "both ports and x-ports specified",
+			content: `
+services:
+  web:
+    image: nginx
+    ports:
+      - "80:8080"
+    x-ports:
+      - "443:8443/https"
+`,
+			wantErr: `service "web" cannot specify both 'ports' and 'x-ports' directives, use only one`,
+		},
+		{
+			name: "only ports specified",
+			content: `
+services:
+  web:
+    image: nginx
+    ports:
+      - "80:8080"
+`,
+		},
+		{
+			name: "only x-ports specified",
+			content: `
+services:
+  web:
+    image: nginx
+    x-ports:
+      - "80:8080/tcp@host"
+`,
+		},
+		{
+			name: "no ports specified",
+			content: `
+services:
+  web:
+    image: nginx
+`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			project, err := loadProjectFromContent(t, tt.content)
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr)
+				return
+			}
+
+			require.NoError(t, err)
+
+			// Verify service exists
+			service, err := project.GetService("web")
+			require.NoError(t, err)
+
+			// Check that ports were processed correctly
+			if specs, ok := service.Extensions[PortsExtensionKey].([]api.PortSpec); ok {
+				// Should have specs if ports were specified
+				assert.NotEmpty(t, specs)
+			}
+		})
+	}
+}
+
+func TestTransformServicesPortsExtension_StandardPorts(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		content  string
+		expected []api.PortSpec
+	}{
+		{
+			name: "standard ports short syntax",
+			content: `
+services:
+  web:
+    image: nginx
+    ports:
+      - "80:8080"
+      - "443:8443/tcp"
+      - "53:5353/udp"
+`,
+			expected: []api.PortSpec{
+				{ContainerPort: 8080, PublishedPort: 80, Protocol: "tcp", Mode: "host"},
+				{ContainerPort: 8443, PublishedPort: 443, Protocol: "tcp", Mode: "host"},
+				{ContainerPort: 5353, PublishedPort: 53, Protocol: "udp", Mode: "host"},
+			},
+		},
+		{
+			name: "standard ports long syntax",
+			content: `
+services:
+  web:
+    image: nginx
+    ports:
+      - target: 8080
+        published: 80
+        protocol: tcp
+        mode: ingress
+      - target: 8443
+        published: 443
+        protocol: tcp
+        mode: host
+`,
+			expected: []api.PortSpec{
+				{ContainerPort: 8080, PublishedPort: 80, Protocol: "tcp", Mode: "host"},
+				{ContainerPort: 8443, PublishedPort: 443, Protocol: "tcp", Mode: "host"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			project, err := loadProjectFromContent(t, tt.content)
+			require.NoError(t, err)
+
+			service, err := project.GetService("web")
+			require.NoError(t, err)
+
+			specs, ok := service.Extensions[PortsExtensionKey].([]api.PortSpec)
+			require.True(t, ok, "Service should have port specs")
+
+			assert.ElementsMatch(t, tt.expected, specs)
+		})
+	}
+}
+
+func TestTransformServicesPortsExtension_XPorts(t *testing.T) {
+	t.Parallel()
+
+	content := `
+services:
+  web:
+    image: nginx
+    x-ports:
+      - "80:8080/tcp"
+      - "443:8443/https"
+      - "9090:9090/tcp@host"
+`
+
+	project, err := loadProjectFromContent(t, content)
+	require.NoError(t, err)
+
+	service, err := project.GetService("web")
+	require.NoError(t, err)
+
+	specs, ok := service.Extensions[PortsExtensionKey].([]api.PortSpec)
+	require.True(t, ok, "Service should have port specs")
+
+	// Just verify that x-ports still work - don't check exact values as that's tested elsewhere
+	assert.Len(t, specs, 3)
+}

--- a/pkg/client/connector/ssh.go
+++ b/pkg/client/connector/ssh.go
@@ -3,13 +3,14 @@ package connector
 import (
 	"context"
 	"fmt"
+	"net"
+	"strings"
+
 	"github.com/psviderski/uncloud/internal/machine"
 	"github.com/psviderski/uncloud/internal/sshexec"
 	"golang.org/x/crypto/ssh"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
-	"net"
-	"strings"
 )
 
 type SSHConnectorConfig struct {

--- a/pkg/client/connector/tcp.go
+++ b/pkg/client/connector/tcp.go
@@ -3,9 +3,10 @@ package connector
 import (
 	"context"
 	"fmt"
+	"net/netip"
+
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
-	"net/netip"
 )
 
 // TCPConnector establishes a connection to the machine API through a direct TCP connection to an API endpoint.

--- a/pkg/client/connector/wireguard.go
+++ b/pkg/client/connector/wireguard.go
@@ -3,6 +3,10 @@ package connector
 import (
 	"context"
 	"fmt"
+	"net"
+	"net/netip"
+	"strconv"
+
 	"github.com/psviderski/uncloud/internal/cli/config"
 	machine2 "github.com/psviderski/uncloud/internal/machine"
 	"github.com/psviderski/uncloud/internal/machine/network"
@@ -10,9 +14,6 @@ import (
 	"github.com/psviderski/uncloud/pkg/client"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
-	"net"
-	"net/netip"
-	"strconv"
 )
 
 // WireGuardConnector establishes a connection to the cluster API through a WireGuard tunnel

--- a/pkg/client/deploy/container.go
+++ b/pkg/client/deploy/container.go
@@ -28,7 +28,10 @@ func EvalContainerSpecChange(current api.ServiceSpec, new api.ServiceSpec) Conta
 		return ContainerNeedsRecreate
 	}
 
-	// Pull policy doesn't affect the container configuration.
+	// If pull policy is set to always, the container needs to be recreated.
+	if new.Container.PullPolicy == api.PullPolicyAlways {
+		return ContainerNeedsRecreate
+	}
 	new.Container.PullPolicy = current.Container.PullPolicy
 
 	// Save mutable container resources that can be updated without recreation.

--- a/pkg/client/deploy/container.go
+++ b/pkg/client/deploy/container.go
@@ -11,9 +11,11 @@ import (
 
 type ContainerSpecStatus string
 
-const ContainerUpToDate ContainerSpecStatus = "up-to-date"
-const ContainerNeedsUpdate ContainerSpecStatus = "needs-update"
-const ContainerNeedsRecreate ContainerSpecStatus = "needs-recreate"
+const (
+	ContainerUpToDate      ContainerSpecStatus = "up-to-date"
+	ContainerNeedsUpdate   ContainerSpecStatus = "needs-update"
+	ContainerNeedsRecreate ContainerSpecStatus = "needs-recreate"
+)
 
 func EvalContainerSpecChange(current api.ServiceSpec, new api.ServiceSpec) ContainerSpecStatus {
 	current = current.SetDefaults()

--- a/pkg/client/deploy/container_test.go
+++ b/pkg/client/deploy/container_test.go
@@ -324,6 +324,54 @@ func TestEvalContainerSpecChange_ContainerPrivileged(t *testing.T) {
 	assert.Equal(t, ContainerNeedsRecreate, EvalContainerSpecChange(newSpec, currentSpec))
 }
 
+func TestEvalContainerSpecChange_PullPolicy(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		current string
+		new     string
+		want    ContainerSpecStatus
+	}{
+		{
+			name:    "non-always to always",
+			current: api.PullPolicyMissing,
+			new:     api.PullPolicyAlways,
+			want:    ContainerNeedsRecreate,
+		},
+		{
+			name:    "always to always",
+			current: api.PullPolicyAlways,
+			new:     api.PullPolicyAlways,
+			want:    ContainerNeedsRecreate,
+		},
+		{
+			name:    "always to non-always",
+			current: api.PullPolicyAlways,
+			new:     api.PullPolicyMissing,
+			want:    ContainerUpToDate,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			currentSpec := api.ServiceSpec{
+				Container: api.ContainerSpec{
+					PullPolicy: tt.current,
+				},
+			}
+			newSpec := api.ServiceSpec{
+				Container: api.ContainerSpec{
+					PullPolicy: tt.new,
+				},
+			}
+
+			result := EvalContainerSpecChange(currentSpec, newSpec)
+			assert.Equal(t, tt.want, result)
+		})
+	}
+}
+
 func TestEvalContainerSpecChange_ContainerUser(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/client/dns.go
+++ b/pkg/client/dns.go
@@ -4,6 +4,11 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
+	"net/http"
+	"sync"
+	"time"
+
 	"github.com/cenkalti/backoff/v4"
 	"github.com/docker/compose/v2/pkg/progress"
 	"github.com/psviderski/uncloud/internal/machine/api/pb"
@@ -11,10 +16,6 @@ import (
 	"github.com/psviderski/uncloud/pkg/api"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
-	"io"
-	"net/http"
-	"sync"
-	"time"
 )
 
 // GetDomain returns the cluster domain name or ErrNotFound if it hasn't been reserved yet.

--- a/pkg/client/user.go
+++ b/pkg/client/user.go
@@ -2,10 +2,11 @@ package client
 
 import (
 	"fmt"
+	"net/netip"
+
 	"github.com/psviderski/uncloud/internal/machine/network"
 	"github.com/psviderski/uncloud/internal/secret"
 	"golang.zx2c4.com/wireguard/wgctrl/wgtypes"
-	"net/netip"
 )
 
 type User struct {

--- a/test/e2e/compose_build_test.go
+++ b/test/e2e/compose_build_test.go
@@ -20,7 +20,6 @@ import (
 	"github.com/psviderski/uncloud/pkg/api"
 	"github.com/psviderski/uncloud/pkg/client/compose"
 	"github.com/stretchr/testify/assert"
-
 	"github.com/stretchr/testify/require"
 )
 

--- a/test/e2e/service_test.go
+++ b/test/e2e/service_test.go
@@ -259,8 +259,8 @@ func TestDeployment(t *testing.T) {
 		assert.Len(t, machines.ToSlice(), 3, "Expected 1 container on each machine")
 
 		// TODO: update the container spec in-place if only the placement constraint has changed.
-		//containers = serviceContainerIDs(svc)
-		//assert.True(t, initialContainers.IsSubset(containers), "Expected all initial containers to remain")
+		// containers = serviceContainerIDs(svc)
+		// assert.True(t, initialContainers.IsSubset(containers), "Expected all initial containers to remain")
 	})
 
 	t.Run("caddy", func(t *testing.T) {
@@ -334,7 +334,7 @@ func TestDeployment(t *testing.T) {
 		assertServiceMatchesSpec(t, svc, deployment.Spec)
 
 		assert.Equal(t, c.Machines[0].ID, svc.Containers[0].MachineID)
-		//initialContainerID := svc.Containers[0].Container.ID
+		// initialContainerID := svc.Containers[0].Container.ID
 
 		// Deploy to all machines without a placement constraint.
 		deployment, err = cli.NewCaddyDeployment(image, api.Placement{})
@@ -352,8 +352,8 @@ func TestDeployment(t *testing.T) {
 		machines := serviceMachines(svc)
 		assert.Len(t, machines.ToSlice(), 3, "Expected 1 container on each machine")
 		// TODO: update the container spec in-place if only the placement constraint has changed.
-		//containers := serviceContainerIDs(svc)
-		//assert.True(t, containers.Contains(initialContainerID), "Expected initial container to remain")
+		// containers := serviceContainerIDs(svc)
+		// assert.True(t, containers.Contains(initialContainerID), "Expected initial container to remain")
 	})
 
 	t.Run("replicated", func(t *testing.T) {
@@ -587,7 +587,7 @@ func TestDeployment(t *testing.T) {
 		require.Error(t, err, "Deployment should fail when volume doesn't exist")
 		require.Contains(t, err.Error(), "no machines available")
 		// TODO: implement and check for more details about the failed constraints.
-		//require.Contains(t, err.Error(), "volume 'non-existent-volume' not found")
+		// require.Contains(t, err.Error(), "volume 'non-existent-volume' not found")
 	})
 
 	// Tests that when a volume exists on a single machine, all requested replicas will be deployed to that machine,


### PR DESCRIPTION
  Why this change:
 E2E tests frequently use repeated string literals for test names, container names, and test data. Use constants instead of string literals  reduces test readability without improving maintainability
This is a common practice many projects exclude style linters from test directories

Technical details:
Added exclude-rules section to .golangci.yaml. Excludes goconst linter specifically for path test/e2e. No impact on production code so goconst remains active for all other directories

additionaly, I've enable goimports auto‑sorts and prunes imports, while gci enforces grouping rules together they keep every file consistently formatted and `merge‑conflict‑friendly` without manual effort.
