### PR TITLE
feat: implement service logs command with colored output and strict ordering

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,10 +16,12 @@ update-dev:
 
 update-restart-dev:
 	GOOS=linux GOARCH=amd64 go build -o uncloudd-linux-amd64 ./cmd/uncloudd && \
-		scp uncloudd-linux-amd64 spy@192.168.40.243:~/ && \
-		ssh spy@192.168.40.243 "sudo install ./uncloudd-linux-amd64 /usr/local/bin/uncloudd && sudo systemctl restart uncloud" && \
-		scp uncloudd-linux-amd64 spy@192.168.40.176:~/ && \
-		ssh spy@192.168.40.176 "sudo install ./uncloudd-linux-amd64 /usr/local/bin/uncloudd && sudo systemctl restart uncloud" && \
+		scp uncloudd-linux-amd64 root@77.105.162.30:~/ && \
+		ssh root@77.105.162.30 "sudo install ./uncloudd-linux-amd64 /usr/local/bin/uncloudd && sudo systemctl restart uncloud" && \
+		scp uncloudd-linux-amd64 root@193.8.184.216:~/ && \
+		ssh root@193.8.184.216 "sudo install ./uncloudd-linux-amd64 /usr/local/bin/uncloudd && sudo systemctl restart uncloud" && \
+		scp uncloudd-linux-amd64 root@193.8.184.128:~/ && \
+        ssh root@193.8.184.128 "sudo install ./uncloudd-linux-amd64 /usr/local/bin/uncloudd && sudo systemctl restart uncloud" && \
 		rm uncloudd-linux-amd64
 #	GOOS=linux GOARCH=arm64 go build -o uncloudd-linux-arm64 ./cmd/uncloudd && \
 #		scp uncloudd-linux-arm64 ubuntu@152.67.101.197:~/ && \

--- a/cmd/uncloud/logs/root.go
+++ b/cmd/uncloud/logs/root.go
@@ -1,0 +1,416 @@
+package logs
+
+import (
+	"container/heap"
+	"context"
+	"fmt"
+	"hash/fnv"
+	"os"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/fatih/color"
+	"github.com/psviderski/uncloud/internal/cli"
+	"github.com/psviderski/uncloud/internal/machine/api/pb"
+	"github.com/psviderski/uncloud/internal/machine/docker"
+	"github.com/psviderski/uncloud/pkg/api"
+	"github.com/psviderski/uncloud/pkg/client"
+	"github.com/spf13/cobra"
+	"google.golang.org/grpc/metadata"
+)
+
+func NewRootCommand() *cobra.Command {
+	var options logsOptions
+
+	cmd := &cobra.Command{
+		Use:     "logs SERVICE",
+		Aliases: []string{"log"},
+		Short:   "View service logs",
+		Long: `View logs from all replicas of a service.
+
+The logs command retrieves and displays logs from all running replicas
+of the specified service across all machines in the cluster.`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			uncli := cmd.Context().Value("cli").(*cli.CLI)
+			return streamLogs(cmd.Context(), uncli, args[0], options)
+		},
+	}
+
+	cmd.Flags().StringVarP(&options.context, "context", "c", "",
+		"Name of the cluster context. (default is the current context)")
+	cmd.Flags().BoolVarP(&options.follow, "follow", "f", false,
+		"Follow log output")
+	cmd.Flags().Int64Var(&options.tail, "tail", -1,
+		"Number of lines to show from the end of the logs")
+	cmd.Flags().BoolVarP(&options.timestamps, "timestamps", "t", false,
+		"Show timestamps")
+	cmd.Flags().StringVar(&options.since, "since", "",
+		"Show logs since timestamp or duration (42m for 42 minutes)")
+	cmd.Flags().StringVar(&options.until, "until", "",
+		"Show logs before a timestamp or duration (42m for 42 minutes)")
+	cmd.Flags().BoolVar(&options.strictOrder, "strict-order", false,
+		"Merge logs in strict chronological order (slower but accurate)")
+
+	return cmd
+}
+
+type logsOptions struct {
+	context     string
+	follow      bool
+	tail        int64
+	timestamps  bool
+	since       string
+	until       string
+	strictOrder bool
+}
+
+func streamLogs(ctx context.Context, uncli *cli.CLI, serviceName string, opts logsOptions) error {
+	c, err := uncli.ConnectCluster(ctx, opts.context)
+	if err != nil {
+		return fmt.Errorf("connect to cluster: %w", err)
+	}
+	defer c.Close()
+
+	// Get service info to find all replicas
+	service, err := c.InspectService(ctx, serviceName)
+	if err != nil {
+		return fmt.Errorf("inspect service: %w", err)
+	}
+
+	if len(service.Containers) == 0 {
+		return fmt.Errorf("no containers found for service %s", serviceName)
+	}
+
+	// Group containers by machine
+	containersByMachine := make(map[string][]api.MachineServiceContainer)
+	for _, container := range service.Containers {
+		containersByMachine[container.MachineID] = append(containersByMachine[container.MachineID], container)
+	}
+
+	// Choose between fast mode and strict ordering mode
+	if opts.strictOrder {
+		return streamLogsOrdered(ctx, c, containersByMachine, serviceName, opts)
+	}
+
+	// use by default: logs are printed as they arrive
+	return streamLogsFast(ctx, c, containersByMachine, serviceName, opts)
+}
+
+// streamLogsFast is the default fast mode that prints logs as they arrive
+func streamLogsFast(ctx context.Context, client *client.Client, containersByMachine map[string][]api.MachineServiceContainer, serviceName string, opts logsOptions) error {
+	logChan := make(chan logEntry, 100)
+	errChan := make(chan error, len(containersByMachine))
+	var wg sync.WaitGroup
+
+	// Start streaming logs from each machine
+	for machine, containers := range containersByMachine {
+		wg.Add(1)
+		go func(machine string, containers []api.MachineServiceContainer) {
+			defer wg.Done()
+			if err := streamMachineLogs(ctx, client, machine, containers, serviceName, opts, logChan); err != nil {
+				errChan <- fmt.Errorf("stream logs from machine %s: %w", machine, err)
+			}
+		}(machine, containers)
+	}
+
+	go func() {
+		wg.Wait()
+		close(logChan)
+		close(errChan)
+	}()
+
+	// Print logs as they arrive
+	for {
+		select {
+		case log, ok := <-logChan:
+			if !ok {
+				// All streams completed
+				return nil
+			}
+			printLogEntry(log, opts.timestamps)
+		case err := <-errChan:
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "Warning: %v\n", err)
+			}
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+}
+
+type logEntry struct {
+	timestamp   time.Time
+	machineID   string
+	machineName string
+	serviceName string
+	replica     string
+	stream      string // stdout or stderr
+	message     string
+}
+
+// logEntryWithChannel wraps a log entry with its source channel for heap ordering
+type logEntryWithChannel struct {
+	entry   logEntry
+	channel <-chan logEntry
+	index   int // index in the heap
+}
+
+// logEntryHeap implements heap.Interface for ordering log entries by timestamp
+type logEntryHeap []*logEntryWithChannel
+
+func (h logEntryHeap) Len() int { return len(h) }
+
+func (h logEntryHeap) Less(i, j int) bool {
+	// Earlier timestamps come first
+	return h[i].entry.timestamp.Before(h[j].entry.timestamp)
+}
+
+func (h logEntryHeap) Swap(i, j int) {
+	h[i], h[j] = h[j], h[i]
+	h[i].index = i
+	h[j].index = j
+}
+
+func (h *logEntryHeap) Push(x interface{}) {
+	n := len(*h)
+	item := x.(*logEntryWithChannel)
+	item.index = n
+	*h = append(*h, item)
+}
+
+func (h *logEntryHeap) Pop() interface{} {
+	old := *h
+	n := len(old)
+	item := old[n-1]
+	old[n-1] = nil  // avoid memory leak
+	item.index = -1 // for safety
+	*h = old[0 : n-1]
+	return item
+}
+
+// streamLogsOrdered implements strict chronological ordering using a min-heap
+func streamLogsOrdered(ctx context.Context, client *client.Client, containersByMachine map[string][]api.MachineServiceContainer, serviceName string, opts logsOptions) error {
+	// Create separate channels for each machine
+	machineChannels := make(map[string]chan logEntry)
+	errChan := make(chan error, len(containersByMachine))
+	var wg sync.WaitGroup
+
+	// Start streaming logs from each machine into separate channels
+	for machine, containers := range containersByMachine {
+		ch := make(chan logEntry, 100)
+		machineChannels[machine] = ch
+
+		wg.Add(1)
+		go func(machine string, containers []api.MachineServiceContainer, ch chan<- logEntry) {
+			defer wg.Done()
+			defer close(ch)
+			if err := streamMachineLogs(ctx, client, machine, containers, serviceName, opts, ch); err != nil {
+				errChan <- fmt.Errorf("stream logs from machine %s: %w", machine, err)
+			}
+		}(machine, containers, ch)
+	}
+
+	go func() {
+		wg.Wait()
+		close(errChan)
+	}()
+
+	h := &logEntryHeap{}
+	heap.Init(h)
+
+	// Read initial entries from each channel
+	for _, ch := range machineChannels {
+		select {
+		case entry, ok := <-ch:
+			if ok {
+				heap.Push(h, &logEntryWithChannel{
+					entry:   entry,
+					channel: ch,
+				})
+			}
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+
+	// Process log entries in chronological order
+	for h.Len() > 0 {
+		select {
+		case err := <-errChan:
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "Warning: %v\n", err)
+			}
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+		}
+
+		item := heap.Pop(h).(*logEntryWithChannel)
+		printLogEntry(item.entry, opts.timestamps)
+
+		// Try to read the next entry from the same channel
+		select {
+		case entry, ok := <-item.channel:
+			if ok {
+				heap.Push(h, &logEntryWithChannel{
+					entry:   entry,
+					channel: item.channel,
+				})
+			}
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+			select {
+			case entry, ok := <-item.channel:
+				if ok {
+					heap.Push(h, &logEntryWithChannel{
+						entry:   entry,
+						channel: item.channel,
+					})
+				}
+			default:
+				// Channel is truly empty, don't re-add
+			}
+		}
+	}
+
+	// Drain any remaining errors
+	for err := range errChan {
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Warning: %v\n", err)
+		}
+	}
+
+	return nil
+}
+
+func streamMachineLogs(ctx context.Context, client *client.Client, machine string, containers []api.MachineServiceContainer, serviceName string, opts logsOptions, logChan chan<- logEntry) error {
+	// Get machine info to proxy requests
+	machineInfo, err := client.InspectMachine(ctx, machine)
+	if err != nil {
+		return fmt.Errorf("inspect machine %s: %w", machine, err)
+	}
+
+	// Create context that proxies to this specific machine
+	machineCtx := proxyToMachine(ctx, machineInfo.Machine)
+
+	// Stream logs from each container
+	var wg sync.WaitGroup
+	for _, container := range containers {
+		wg.Add(1)
+		go func(container api.MachineServiceContainer) {
+			defer wg.Done()
+			if err := streamContainerLogs(machineCtx, client, machineInfo.Machine.Id, machineInfo.Machine.Name, container, serviceName, opts, logChan); err != nil {
+				// Log error but don't fail the whole operation
+				fmt.Fprintf(os.Stderr, "Warning: failed to stream logs for container %s: %v\n", container.Container.ID, err)
+			}
+		}(container)
+	}
+	wg.Wait()
+	return nil
+}
+
+func streamContainerLogs(ctx context.Context, client *client.Client, machineID string, machineName string, container api.MachineServiceContainer, serviceName string, opts logsOptions, logChan chan<- logEntry) error {
+	dockerOpts := docker.ContainerLogsOptions{
+		Follow:     opts.follow,
+		Tail:       opts.tail,
+		Timestamps: opts.timestamps,
+		Since:      opts.since,
+		Until:      opts.until,
+	}
+
+	// Get container logs channel from Docker
+	logsChan, err := client.Docker.ContainerLogs(ctx, container.Container.ID, dockerOpts)
+	if err != nil {
+		return fmt.Errorf("get container logs: %w", err)
+	}
+
+	// Read from Docker logs channel and forward to our channel
+	for entry := range logsChan {
+		stream := "stdout"
+		if entry.StreamType == 2 {
+			stream = "stderr"
+		}
+
+		// Parse timestamp if provided
+		var timestamp time.Time
+		if entry.Timestamp != "" {
+			timestamp, _ = time.Parse(time.RFC3339Nano, entry.Timestamp)
+		} else {
+			timestamp = time.Now()
+		}
+
+		logChan <- logEntry{
+			timestamp:   timestamp,
+			machineID:   machineID,
+			machineName: machineName,
+			serviceName: serviceName,
+			replica:     container.Container.Name,
+			stream:      stream,
+			message:     entry.Message,
+		}
+	}
+
+	return nil
+}
+
+// proxyToMachine returns a new context that proxies gRPC requests to the specified machine.
+func proxyToMachine(ctx context.Context, machine *pb.MachineInfo) context.Context {
+	machineIP, _ := machine.Network.ManagementIp.ToAddr()
+	md := metadata.Pairs("machines", machineIP.String())
+	return metadata.NewOutgoingContext(ctx, md)
+}
+
+// getMachineColor returns a consistent color for a given machine ID
+func getMachineColor(machineID string) *color.Color {
+	h := fnv.New32a()
+	h.Write([]byte(machineID))
+	hash := h.Sum32()
+
+	colors := []*color.Color{
+		color.New(color.FgCyan),
+		color.New(color.FgGreen),
+		color.New(color.FgYellow),
+		color.New(color.FgBlue),
+		color.New(color.FgMagenta),
+		color.New(color.FgRed),
+		color.New(color.FgHiCyan),
+		color.New(color.FgHiGreen),
+		color.New(color.FgHiYellow),
+		color.New(color.FgHiBlue),
+		color.New(color.FgHiMagenta),
+		color.New(color.FgHiRed),
+	}
+	colorIndex := hash % uint32(len(colors))
+	return colors[colorIndex]
+}
+
+func printLogEntry(entry logEntry, showTimestamp bool) {
+	var output strings.Builder
+
+	if showTimestamp {
+		output.WriteString(entry.timestamp.Format(time.DateTime))
+		output.WriteString(" ")
+	}
+
+	// Get color for machine ID
+	machineColor := getMachineColor(entry.machineID)
+
+	// Format colored prefix: [machineName (machineID)/serviceName]
+	prefix := fmt.Sprintf("[%s (%s)/%s]", entry.machineName, entry.machineID, entry.serviceName)
+	coloredPrefix := machineColor.Sprint(prefix)
+
+	// Build final output
+	output.WriteString(coloredPrefix)
+	output.WriteString(" ")
+	output.WriteString(entry.message)
+
+	// Print to appropriate stream
+	if entry.stream == "stderr" {
+		fmt.Fprintln(os.Stderr, output.String())
+	} else {
+		fmt.Println(output.String())
+	}
+}

--- a/cmd/uncloud/main.go
+++ b/cmd/uncloud/main.go
@@ -9,6 +9,7 @@ import (
 	"github.com/psviderski/uncloud/cmd/uncloud/caddy"
 	cmdcontext "github.com/psviderski/uncloud/cmd/uncloud/context"
 	"github.com/psviderski/uncloud/cmd/uncloud/dns"
+	"github.com/psviderski/uncloud/cmd/uncloud/logs"
 	"github.com/psviderski/uncloud/cmd/uncloud/machine"
 	"github.com/psviderski/uncloud/cmd/uncloud/service"
 	"github.com/psviderski/uncloud/cmd/uncloud/volume"
@@ -79,6 +80,7 @@ func main() {
 		caddy.NewRootCommand(),
 		cmdcontext.NewRootCommand(),
 		dns.NewRootCommand(),
+		logs.NewRootCommand(),
 		machine.NewRootCommand(),
 		service.NewRootCommand(),
 		service.NewInspectCommand(),

--- a/go.mod
+++ b/go.mod
@@ -115,7 +115,7 @@ require (
 	github.com/docker/go-metrics v0.0.1 // indirect
 	github.com/dustin/go-humanize v1.0.1 // indirect
 	github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f // indirect
-	github.com/fatih/color v1.17.0 // indirect
+	github.com/fatih/color v1.18.0 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
 	github.com/fvbommel/sortorder v1.1.0 // indirect
 	github.com/go-jose/go-jose/v3 v3.0.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -303,6 +303,8 @@ github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5Kwzbycv
 github.com/fatih/color v1.9.0/go.mod h1:eQcE1qtQxscV5RaZvpXrrb8Drkc3/DdQ+uUYCNjL+zU=
 github.com/fatih/color v1.17.0 h1:GlRw1BRJxkpqUCBKzKOw098ed57fEsKeNjpTe3cSjK4=
 github.com/fatih/color v1.17.0/go.mod h1:YZ7TlrGPkiz6ku9fK3TLD/pl3CpsiFyu8N92HLgmosI=
+github.com/fatih/color v1.18.0 h1:S8gINlzdQ840/4pfAwic/ZE0djQEH3wM94VfqLTZcOM=
+github.com/fatih/color v1.18.0/go.mod h1:4FelSpRwEGDpQ12mAdzqdOukCy4u8WUtOY6lkT/6HfU=
 github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2Wg=
 github.com/felixge/httpsnoop v1.0.4/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/flynn/noise v1.1.0 h1:KjPQoQCEFdZDiP03phOvGi11+SVVhBG2wOWAorLsstg=

--- a/internal/machine/api/pb/docker.pb.go
+++ b/internal/machine/api/pb/docker.pb.go
@@ -1566,6 +1566,168 @@ func (x *MachineServiceContainers) GetContainers() []*ServiceContainer {
 	return nil
 }
 
+type ContainerLogsRequest struct {
+	state         protoimpl.MessageState
+	sizeCache     protoimpl.SizeCache
+	unknownFields protoimpl.UnknownFields
+
+	ContainerId string `protobuf:"bytes,1,opt,name=container_id,json=containerId,proto3" json:"container_id,omitempty"`
+	// Options for logs retrieval.
+	Follow     bool   `protobuf:"varint,2,opt,name=follow,proto3" json:"follow,omitempty"`
+	Tail       int64  `protobuf:"varint,3,opt,name=tail,proto3" json:"tail,omitempty"` // -1 means all
+	Timestamps bool   `protobuf:"varint,4,opt,name=timestamps,proto3" json:"timestamps,omitempty"`
+	Since      string `protobuf:"bytes,5,opt,name=since,proto3" json:"since,omitempty"`      // RFC3339 timestamp or duration string
+	Until      string `protobuf:"bytes,6,opt,name=until,proto3" json:"until,omitempty"`      // RFC3339 timestamp or duration string
+	Details    bool   `protobuf:"varint,7,opt,name=details,proto3" json:"details,omitempty"` // Show extra details (e.g., container labels)
+}
+
+func (x *ContainerLogsRequest) Reset() {
+	*x = ContainerLogsRequest{}
+	if protoimpl.UnsafeEnabled {
+		mi := &file_internal_machine_api_pb_docker_proto_msgTypes[29]
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		ms.StoreMessageInfo(mi)
+	}
+}
+
+func (x *ContainerLogsRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ContainerLogsRequest) ProtoMessage() {}
+
+func (x *ContainerLogsRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_internal_machine_api_pb_docker_proto_msgTypes[29]
+	if protoimpl.UnsafeEnabled && x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ContainerLogsRequest.ProtoReflect.Descriptor instead.
+func (*ContainerLogsRequest) Descriptor() ([]byte, []int) {
+	return file_internal_machine_api_pb_docker_proto_rawDescGZIP(), []int{29}
+}
+
+func (x *ContainerLogsRequest) GetContainerId() string {
+	if x != nil {
+		return x.ContainerId
+	}
+	return ""
+}
+
+func (x *ContainerLogsRequest) GetFollow() bool {
+	if x != nil {
+		return x.Follow
+	}
+	return false
+}
+
+func (x *ContainerLogsRequest) GetTail() int64 {
+	if x != nil {
+		return x.Tail
+	}
+	return 0
+}
+
+func (x *ContainerLogsRequest) GetTimestamps() bool {
+	if x != nil {
+		return x.Timestamps
+	}
+	return false
+}
+
+func (x *ContainerLogsRequest) GetSince() string {
+	if x != nil {
+		return x.Since
+	}
+	return ""
+}
+
+func (x *ContainerLogsRequest) GetUntil() string {
+	if x != nil {
+		return x.Until
+	}
+	return ""
+}
+
+func (x *ContainerLogsRequest) GetDetails() bool {
+	if x != nil {
+		return x.Details
+	}
+	return false
+}
+
+type ContainerLogsResponse struct {
+	state         protoimpl.MessageState
+	sizeCache     protoimpl.SizeCache
+	unknownFields protoimpl.UnknownFields
+
+	// Stream type: 1 = stdout, 2 = stderr
+	StreamType int32 `protobuf:"varint,1,opt,name=stream_type,json=streamType,proto3" json:"stream_type,omitempty"`
+	// Log line content (without newline)
+	Message string `protobuf:"bytes,2,opt,name=message,proto3" json:"message,omitempty"`
+	// Optional timestamp if timestamps requested
+	Timestamp string `protobuf:"bytes,3,opt,name=timestamp,proto3" json:"timestamp,omitempty"`
+}
+
+func (x *ContainerLogsResponse) Reset() {
+	*x = ContainerLogsResponse{}
+	if protoimpl.UnsafeEnabled {
+		mi := &file_internal_machine_api_pb_docker_proto_msgTypes[30]
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		ms.StoreMessageInfo(mi)
+	}
+}
+
+func (x *ContainerLogsResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ContainerLogsResponse) ProtoMessage() {}
+
+func (x *ContainerLogsResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_internal_machine_api_pb_docker_proto_msgTypes[30]
+	if protoimpl.UnsafeEnabled && x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ContainerLogsResponse.ProtoReflect.Descriptor instead.
+func (*ContainerLogsResponse) Descriptor() ([]byte, []int) {
+	return file_internal_machine_api_pb_docker_proto_rawDescGZIP(), []int{30}
+}
+
+func (x *ContainerLogsResponse) GetStreamType() int32 {
+	if x != nil {
+		return x.StreamType
+	}
+	return 0
+}
+
+func (x *ContainerLogsResponse) GetMessage() string {
+	if x != nil {
+		return x.Message
+	}
+	return ""
+}
+
+func (x *ContainerLogsResponse) GetTimestamp() string {
+	if x != nil {
+		return x.Timestamp
+	}
+	return ""
+}
+
 var File_internal_machine_api_pb_docker_proto protoreflect.FileDescriptor
 
 var file_internal_machine_api_pb_docker_proto_rawDesc = []byte{
@@ -1711,7 +1873,27 @@ var file_internal_machine_api_pb_docker_proto_rawDesc = []byte{
 	0x61, 0x74, 0x61, 0x12, 0x35, 0x0a, 0x0a, 0x63, 0x6f, 0x6e, 0x74, 0x61, 0x69, 0x6e, 0x65, 0x72,
 	0x73, 0x18, 0x02, 0x20, 0x03, 0x28, 0x0b, 0x32, 0x15, 0x2e, 0x61, 0x70, 0x69, 0x2e, 0x53, 0x65,
 	0x72, 0x76, 0x69, 0x63, 0x65, 0x43, 0x6f, 0x6e, 0x74, 0x61, 0x69, 0x6e, 0x65, 0x72, 0x52, 0x0a,
-	0x63, 0x6f, 0x6e, 0x74, 0x61, 0x69, 0x6e, 0x65, 0x72, 0x73, 0x32, 0xbc, 0x09, 0x0a, 0x06, 0x44,
+	0x63, 0x6f, 0x6e, 0x74, 0x61, 0x69, 0x6e, 0x65, 0x72, 0x73, 0x22, 0xcb, 0x01, 0x0a, 0x14, 0x43,
+	0x6f, 0x6e, 0x74, 0x61, 0x69, 0x6e, 0x65, 0x72, 0x4c, 0x6f, 0x67, 0x73, 0x52, 0x65, 0x71, 0x75,
+	0x65, 0x73, 0x74, 0x12, 0x21, 0x0a, 0x0c, 0x63, 0x6f, 0x6e, 0x74, 0x61, 0x69, 0x6e, 0x65, 0x72,
+	0x5f, 0x69, 0x64, 0x18, 0x01, 0x20, 0x01, 0x28, 0x09, 0x52, 0x0b, 0x63, 0x6f, 0x6e, 0x74, 0x61,
+	0x69, 0x6e, 0x65, 0x72, 0x49, 0x64, 0x12, 0x16, 0x0a, 0x06, 0x66, 0x6f, 0x6c, 0x6c, 0x6f, 0x77,
+	0x18, 0x02, 0x20, 0x01, 0x28, 0x08, 0x52, 0x06, 0x66, 0x6f, 0x6c, 0x6c, 0x6f, 0x77, 0x12, 0x12,
+	0x0a, 0x04, 0x74, 0x61, 0x69, 0x6c, 0x18, 0x03, 0x20, 0x01, 0x28, 0x03, 0x52, 0x04, 0x74, 0x61,
+	0x69, 0x6c, 0x12, 0x1e, 0x0a, 0x0a, 0x74, 0x69, 0x6d, 0x65, 0x73, 0x74, 0x61, 0x6d, 0x70, 0x73,
+	0x18, 0x04, 0x20, 0x01, 0x28, 0x08, 0x52, 0x0a, 0x74, 0x69, 0x6d, 0x65, 0x73, 0x74, 0x61, 0x6d,
+	0x70, 0x73, 0x12, 0x14, 0x0a, 0x05, 0x73, 0x69, 0x6e, 0x63, 0x65, 0x18, 0x05, 0x20, 0x01, 0x28,
+	0x09, 0x52, 0x05, 0x73, 0x69, 0x6e, 0x63, 0x65, 0x12, 0x14, 0x0a, 0x05, 0x75, 0x6e, 0x74, 0x69,
+	0x6c, 0x18, 0x06, 0x20, 0x01, 0x28, 0x09, 0x52, 0x05, 0x75, 0x6e, 0x74, 0x69, 0x6c, 0x12, 0x18,
+	0x0a, 0x07, 0x64, 0x65, 0x74, 0x61, 0x69, 0x6c, 0x73, 0x18, 0x07, 0x20, 0x01, 0x28, 0x08, 0x52,
+	0x07, 0x64, 0x65, 0x74, 0x61, 0x69, 0x6c, 0x73, 0x22, 0x70, 0x0a, 0x15, 0x43, 0x6f, 0x6e, 0x74,
+	0x61, 0x69, 0x6e, 0x65, 0x72, 0x4c, 0x6f, 0x67, 0x73, 0x52, 0x65, 0x73, 0x70, 0x6f, 0x6e, 0x73,
+	0x65, 0x12, 0x1f, 0x0a, 0x0b, 0x73, 0x74, 0x72, 0x65, 0x61, 0x6d, 0x5f, 0x74, 0x79, 0x70, 0x65,
+	0x18, 0x01, 0x20, 0x01, 0x28, 0x05, 0x52, 0x0a, 0x73, 0x74, 0x72, 0x65, 0x61, 0x6d, 0x54, 0x79,
+	0x70, 0x65, 0x12, 0x18, 0x0a, 0x07, 0x6d, 0x65, 0x73, 0x73, 0x61, 0x67, 0x65, 0x18, 0x02, 0x20,
+	0x01, 0x28, 0x09, 0x52, 0x07, 0x6d, 0x65, 0x73, 0x73, 0x61, 0x67, 0x65, 0x12, 0x1c, 0x0a, 0x09,
+	0x74, 0x69, 0x6d, 0x65, 0x73, 0x74, 0x61, 0x6d, 0x70, 0x18, 0x03, 0x20, 0x01, 0x28, 0x09, 0x52,
+	0x09, 0x74, 0x69, 0x6d, 0x65, 0x73, 0x74, 0x61, 0x6d, 0x70, 0x32, 0x86, 0x0a, 0x0a, 0x06, 0x44,
 	0x6f, 0x63, 0x6b, 0x65, 0x72, 0x12, 0x4c, 0x0a, 0x0f, 0x43, 0x72, 0x65, 0x61, 0x74, 0x65, 0x43,
 	0x6f, 0x6e, 0x74, 0x61, 0x69, 0x6e, 0x65, 0x72, 0x12, 0x1b, 0x2e, 0x61, 0x70, 0x69, 0x2e, 0x43,
 	0x72, 0x65, 0x61, 0x74, 0x65, 0x43, 0x6f, 0x6e, 0x74, 0x61, 0x69, 0x6e, 0x65, 0x72, 0x52, 0x65,
@@ -1787,11 +1969,16 @@ var file_internal_machine_api_pb_docker_proto_rawDesc = []byte{
 	0x69, 0x6e, 0x65, 0x72, 0x12, 0x1b, 0x2e, 0x61, 0x70, 0x69, 0x2e, 0x52, 0x65, 0x6d, 0x6f, 0x76,
 	0x65, 0x43, 0x6f, 0x6e, 0x74, 0x61, 0x69, 0x6e, 0x65, 0x72, 0x52, 0x65, 0x71, 0x75, 0x65, 0x73,
 	0x74, 0x1a, 0x16, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f,
-	0x62, 0x75, 0x66, 0x2e, 0x45, 0x6d, 0x70, 0x74, 0x79, 0x42, 0x37, 0x5a, 0x35, 0x67, 0x69, 0x74,
-	0x68, 0x75, 0x62, 0x2e, 0x63, 0x6f, 0x6d, 0x2f, 0x70, 0x73, 0x76, 0x69, 0x64, 0x65, 0x72, 0x73,
-	0x6b, 0x69, 0x2f, 0x75, 0x6e, 0x63, 0x6c, 0x6f, 0x75, 0x64, 0x2f, 0x69, 0x6e, 0x74, 0x65, 0x72,
-	0x6e, 0x61, 0x6c, 0x2f, 0x6d, 0x61, 0x63, 0x68, 0x69, 0x6e, 0x65, 0x2f, 0x61, 0x70, 0x69, 0x2f,
-	0x70, 0x62, 0x62, 0x06, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x33,
+	0x62, 0x75, 0x66, 0x2e, 0x45, 0x6d, 0x70, 0x74, 0x79, 0x12, 0x48, 0x0a, 0x0d, 0x43, 0x6f, 0x6e,
+	0x74, 0x61, 0x69, 0x6e, 0x65, 0x72, 0x4c, 0x6f, 0x67, 0x73, 0x12, 0x19, 0x2e, 0x61, 0x70, 0x69,
+	0x2e, 0x43, 0x6f, 0x6e, 0x74, 0x61, 0x69, 0x6e, 0x65, 0x72, 0x4c, 0x6f, 0x67, 0x73, 0x52, 0x65,
+	0x71, 0x75, 0x65, 0x73, 0x74, 0x1a, 0x1a, 0x2e, 0x61, 0x70, 0x69, 0x2e, 0x43, 0x6f, 0x6e, 0x74,
+	0x61, 0x69, 0x6e, 0x65, 0x72, 0x4c, 0x6f, 0x67, 0x73, 0x52, 0x65, 0x73, 0x70, 0x6f, 0x6e, 0x73,
+	0x65, 0x30, 0x01, 0x42, 0x37, 0x5a, 0x35, 0x67, 0x69, 0x74, 0x68, 0x75, 0x62, 0x2e, 0x63, 0x6f,
+	0x6d, 0x2f, 0x70, 0x73, 0x76, 0x69, 0x64, 0x65, 0x72, 0x73, 0x6b, 0x69, 0x2f, 0x75, 0x6e, 0x63,
+	0x6c, 0x6f, 0x75, 0x64, 0x2f, 0x69, 0x6e, 0x74, 0x65, 0x72, 0x6e, 0x61, 0x6c, 0x2f, 0x6d, 0x61,
+	0x63, 0x68, 0x69, 0x6e, 0x65, 0x2f, 0x61, 0x70, 0x69, 0x2f, 0x70, 0x62, 0x62, 0x06, 0x70, 0x72,
+	0x6f, 0x74, 0x6f, 0x33,
 }
 
 var (
@@ -1806,7 +1993,7 @@ func file_internal_machine_api_pb_docker_proto_rawDescGZIP() []byte {
 	return file_internal_machine_api_pb_docker_proto_rawDescData
 }
 
-var file_internal_machine_api_pb_docker_proto_msgTypes = make([]protoimpl.MessageInfo, 29)
+var file_internal_machine_api_pb_docker_proto_msgTypes = make([]protoimpl.MessageInfo, 31)
 var file_internal_machine_api_pb_docker_proto_goTypes = []any{
 	(*CreateContainerRequest)(nil),        // 0: api.CreateContainerRequest
 	(*CreateContainerResponse)(nil),       // 1: api.CreateContainerResponse
@@ -1837,20 +2024,22 @@ var file_internal_machine_api_pb_docker_proto_goTypes = []any{
 	(*ListServiceContainersRequest)(nil),  // 26: api.ListServiceContainersRequest
 	(*ListServiceContainersResponse)(nil), // 27: api.ListServiceContainersResponse
 	(*MachineServiceContainers)(nil),      // 28: api.MachineServiceContainers
-	(*Metadata)(nil),                      // 29: api.Metadata
-	(*emptypb.Empty)(nil),                 // 30: google.protobuf.Empty
+	(*ContainerLogsRequest)(nil),          // 29: api.ContainerLogsRequest
+	(*ContainerLogsResponse)(nil),         // 30: api.ContainerLogsResponse
+	(*Metadata)(nil),                      // 31: api.Metadata
+	(*emptypb.Empty)(nil),                 // 32: google.protobuf.Empty
 }
 var file_internal_machine_api_pb_docker_proto_depIdxs = []int32{
 	8,  // 0: api.ListContainersResponse.messages:type_name -> api.MachineContainers
-	29, // 1: api.MachineContainers.metadata:type_name -> api.Metadata
+	31, // 1: api.MachineContainers.metadata:type_name -> api.Metadata
 	14, // 2: api.InspectImageResponse.messages:type_name -> api.Image
-	29, // 3: api.Image.metadata:type_name -> api.Metadata
+	31, // 3: api.Image.metadata:type_name -> api.Metadata
 	17, // 4: api.InspectRemoteImageResponse.messages:type_name -> api.RemoteImage
-	29, // 5: api.RemoteImage.metadata:type_name -> api.Metadata
+	31, // 5: api.RemoteImage.metadata:type_name -> api.Metadata
 	22, // 6: api.ListVolumesResponse.messages:type_name -> api.MachineVolumes
-	29, // 7: api.MachineVolumes.metadata:type_name -> api.Metadata
+	31, // 7: api.MachineVolumes.metadata:type_name -> api.Metadata
 	28, // 8: api.ListServiceContainersResponse.messages:type_name -> api.MachineServiceContainers
-	29, // 9: api.MachineServiceContainers.metadata:type_name -> api.Metadata
+	31, // 9: api.MachineServiceContainers.metadata:type_name -> api.Metadata
 	25, // 10: api.MachineServiceContainers.containers:type_name -> api.ServiceContainer
 	0,  // 11: api.Docker.CreateContainer:input_type -> api.CreateContainerRequest
 	2,  // 12: api.Docker.InspectContainer:input_type -> api.InspectContainerRequest
@@ -1868,24 +2057,26 @@ var file_internal_machine_api_pb_docker_proto_depIdxs = []int32{
 	2,  // 24: api.Docker.InspectServiceContainer:input_type -> api.InspectContainerRequest
 	26, // 25: api.Docker.ListServiceContainers:input_type -> api.ListServiceContainersRequest
 	9,  // 26: api.Docker.RemoveServiceContainer:input_type -> api.RemoveContainerRequest
-	1,  // 27: api.Docker.CreateContainer:output_type -> api.CreateContainerResponse
-	3,  // 28: api.Docker.InspectContainer:output_type -> api.InspectContainerResponse
-	30, // 29: api.Docker.StartContainer:output_type -> google.protobuf.Empty
-	30, // 30: api.Docker.StopContainer:output_type -> google.protobuf.Empty
-	7,  // 31: api.Docker.ListContainers:output_type -> api.ListContainersResponse
-	30, // 32: api.Docker.RemoveContainer:output_type -> google.protobuf.Empty
-	11, // 33: api.Docker.PullImage:output_type -> api.JSONMessage
-	13, // 34: api.Docker.InspectImage:output_type -> api.InspectImageResponse
-	16, // 35: api.Docker.InspectRemoteImage:output_type -> api.InspectRemoteImageResponse
-	19, // 36: api.Docker.CreateVolume:output_type -> api.CreateVolumeResponse
-	21, // 37: api.Docker.ListVolumes:output_type -> api.ListVolumesResponse
-	30, // 38: api.Docker.RemoveVolume:output_type -> google.protobuf.Empty
-	1,  // 39: api.Docker.CreateServiceContainer:output_type -> api.CreateContainerResponse
-	25, // 40: api.Docker.InspectServiceContainer:output_type -> api.ServiceContainer
-	27, // 41: api.Docker.ListServiceContainers:output_type -> api.ListServiceContainersResponse
-	30, // 42: api.Docker.RemoveServiceContainer:output_type -> google.protobuf.Empty
-	27, // [27:43] is the sub-list for method output_type
-	11, // [11:27] is the sub-list for method input_type
+	29, // 27: api.Docker.ContainerLogs:input_type -> api.ContainerLogsRequest
+	1,  // 28: api.Docker.CreateContainer:output_type -> api.CreateContainerResponse
+	3,  // 29: api.Docker.InspectContainer:output_type -> api.InspectContainerResponse
+	32, // 30: api.Docker.StartContainer:output_type -> google.protobuf.Empty
+	32, // 31: api.Docker.StopContainer:output_type -> google.protobuf.Empty
+	7,  // 32: api.Docker.ListContainers:output_type -> api.ListContainersResponse
+	32, // 33: api.Docker.RemoveContainer:output_type -> google.protobuf.Empty
+	11, // 34: api.Docker.PullImage:output_type -> api.JSONMessage
+	13, // 35: api.Docker.InspectImage:output_type -> api.InspectImageResponse
+	16, // 36: api.Docker.InspectRemoteImage:output_type -> api.InspectRemoteImageResponse
+	19, // 37: api.Docker.CreateVolume:output_type -> api.CreateVolumeResponse
+	21, // 38: api.Docker.ListVolumes:output_type -> api.ListVolumesResponse
+	32, // 39: api.Docker.RemoveVolume:output_type -> google.protobuf.Empty
+	1,  // 40: api.Docker.CreateServiceContainer:output_type -> api.CreateContainerResponse
+	25, // 41: api.Docker.InspectServiceContainer:output_type -> api.ServiceContainer
+	27, // 42: api.Docker.ListServiceContainers:output_type -> api.ListServiceContainersResponse
+	32, // 43: api.Docker.RemoveServiceContainer:output_type -> google.protobuf.Empty
+	30, // 44: api.Docker.ContainerLogs:output_type -> api.ContainerLogsResponse
+	28, // [28:45] is the sub-list for method output_type
+	11, // [11:28] is the sub-list for method input_type
 	11, // [11:11] is the sub-list for extension type_name
 	11, // [11:11] is the sub-list for extension extendee
 	0,  // [0:11] is the sub-list for field type_name
@@ -2246,6 +2437,30 @@ func file_internal_machine_api_pb_docker_proto_init() {
 				return nil
 			}
 		}
+		file_internal_machine_api_pb_docker_proto_msgTypes[29].Exporter = func(v any, i int) any {
+			switch v := v.(*ContainerLogsRequest); i {
+			case 0:
+				return &v.state
+			case 1:
+				return &v.sizeCache
+			case 2:
+				return &v.unknownFields
+			default:
+				return nil
+			}
+		}
+		file_internal_machine_api_pb_docker_proto_msgTypes[30].Exporter = func(v any, i int) any {
+			switch v := v.(*ContainerLogsResponse); i {
+			case 0:
+				return &v.state
+			case 1:
+				return &v.sizeCache
+			case 2:
+				return &v.unknownFields
+			default:
+				return nil
+			}
+		}
 	}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
@@ -2253,7 +2468,7 @@ func file_internal_machine_api_pb_docker_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: file_internal_machine_api_pb_docker_proto_rawDesc,
 			NumEnums:      0,
-			NumMessages:   29,
+			NumMessages:   31,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/internal/machine/api/pb/docker.proto
+++ b/internal/machine/api/pb/docker.proto
@@ -29,6 +29,9 @@ service Docker {
   rpc InspectServiceContainer(InspectContainerRequest) returns (ServiceContainer);
   rpc ListServiceContainers(ListServiceContainersRequest) returns (ListServiceContainersResponse);
   rpc RemoveServiceContainer(RemoveContainerRequest) returns (google.protobuf.Empty);
+
+  // ContainerLogs streams logs from a container
+  rpc ContainerLogs(ContainerLogsRequest) returns (stream ContainerLogsResponse);
 }
 
 message CreateContainerRequest {
@@ -194,4 +197,24 @@ message ListServiceContainersResponse {
 message MachineServiceContainers {
   Metadata metadata = 1;
   repeated ServiceContainer containers = 2;
+}
+
+message ContainerLogsRequest {
+  string container_id = 1;
+  // Options for logs retrieval
+  bool follow = 2;
+  int64 tail = 3; // -1 means all
+  bool timestamps = 4;
+  string since = 5; // https://www.rfc-editor.org/rfc/rfc3339.html timestamp or duration string
+  string until = 6; // https://www.rfc-editor.org/rfc/rfc3339.html timestamp or duration string
+  bool details = 7; // TODO: reserve for show extra details (container labels or smth like this)
+}
+
+message ContainerLogsResponse {
+  // Stream type: 1 = stdout, 2 = stderr
+  int32 stream_type = 1;
+  // Log line content
+  string message = 2;
+  // Optional timestamp if timestamps requested
+  string timestamp = 3;
 }

--- a/internal/machine/api/pb/docker_grpc.pb.go
+++ b/internal/machine/api/pb/docker_grpc.pb.go
@@ -36,6 +36,7 @@ const (
 	Docker_InspectServiceContainer_FullMethodName = "/api.Docker/InspectServiceContainer"
 	Docker_ListServiceContainers_FullMethodName   = "/api.Docker/ListServiceContainers"
 	Docker_RemoveServiceContainer_FullMethodName  = "/api.Docker/RemoveServiceContainer"
+	Docker_ContainerLogs_FullMethodName           = "/api.Docker/ContainerLogs"
 )
 
 // DockerClient is the client API for Docker service.
@@ -60,6 +61,8 @@ type DockerClient interface {
 	InspectServiceContainer(ctx context.Context, in *InspectContainerRequest, opts ...grpc.CallOption) (*ServiceContainer, error)
 	ListServiceContainers(ctx context.Context, in *ListServiceContainersRequest, opts ...grpc.CallOption) (*ListServiceContainersResponse, error)
 	RemoveServiceContainer(ctx context.Context, in *RemoveContainerRequest, opts ...grpc.CallOption) (*emptypb.Empty, error)
+	// ContainerLogs streams logs from a container.
+	ContainerLogs(ctx context.Context, in *ContainerLogsRequest, opts ...grpc.CallOption) (grpc.ServerStreamingClient[ContainerLogsResponse], error)
 }
 
 type dockerClient struct {
@@ -239,6 +242,25 @@ func (c *dockerClient) RemoveServiceContainer(ctx context.Context, in *RemoveCon
 	return out, nil
 }
 
+func (c *dockerClient) ContainerLogs(ctx context.Context, in *ContainerLogsRequest, opts ...grpc.CallOption) (grpc.ServerStreamingClient[ContainerLogsResponse], error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	stream, err := c.cc.NewStream(ctx, &Docker_ServiceDesc.Streams[1], Docker_ContainerLogs_FullMethodName, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	x := &grpc.GenericClientStream[ContainerLogsRequest, ContainerLogsResponse]{ClientStream: stream}
+	if err := x.ClientStream.SendMsg(in); err != nil {
+		return nil, err
+	}
+	if err := x.ClientStream.CloseSend(); err != nil {
+		return nil, err
+	}
+	return x, nil
+}
+
+// This type alias is provided for backwards compatibility with existing code that references the prior non-generic stream type by name.
+type Docker_ContainerLogsClient = grpc.ServerStreamingClient[ContainerLogsResponse]
+
 // DockerServer is the server API for Docker service.
 // All implementations must embed UnimplementedDockerServer
 // for forward compatibility.
@@ -261,6 +283,8 @@ type DockerServer interface {
 	InspectServiceContainer(context.Context, *InspectContainerRequest) (*ServiceContainer, error)
 	ListServiceContainers(context.Context, *ListServiceContainersRequest) (*ListServiceContainersResponse, error)
 	RemoveServiceContainer(context.Context, *RemoveContainerRequest) (*emptypb.Empty, error)
+	// ContainerLogs streams logs from a container.
+	ContainerLogs(*ContainerLogsRequest, grpc.ServerStreamingServer[ContainerLogsResponse]) error
 	mustEmbedUnimplementedDockerServer()
 }
 
@@ -318,6 +342,9 @@ func (UnimplementedDockerServer) ListServiceContainers(context.Context, *ListSer
 }
 func (UnimplementedDockerServer) RemoveServiceContainer(context.Context, *RemoveContainerRequest) (*emptypb.Empty, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method RemoveServiceContainer not implemented")
+}
+func (UnimplementedDockerServer) ContainerLogs(*ContainerLogsRequest, grpc.ServerStreamingServer[ContainerLogsResponse]) error {
+	return status.Errorf(codes.Unimplemented, "method ContainerLogs not implemented")
 }
 func (UnimplementedDockerServer) mustEmbedUnimplementedDockerServer() {}
 func (UnimplementedDockerServer) testEmbeddedByValue()                {}
@@ -621,6 +648,17 @@ func _Docker_RemoveServiceContainer_Handler(srv interface{}, ctx context.Context
 	return interceptor(ctx, in, info, handler)
 }
 
+func _Docker_ContainerLogs_Handler(srv interface{}, stream grpc.ServerStream) error {
+	m := new(ContainerLogsRequest)
+	if err := stream.RecvMsg(m); err != nil {
+		return err
+	}
+	return srv.(DockerServer).ContainerLogs(m, &grpc.GenericServerStream[ContainerLogsRequest, ContainerLogsResponse]{ServerStream: stream})
+}
+
+// This type alias is provided for backwards compatibility with existing code that references the prior non-generic stream type by name.
+type Docker_ContainerLogsServer = grpc.ServerStreamingServer[ContainerLogsResponse]
+
 // Docker_ServiceDesc is the grpc.ServiceDesc for Docker service.
 // It's only intended for direct use with grpc.RegisterService,
 // and not to be introspected or modified (even as a copy)
@@ -693,6 +731,11 @@ var Docker_ServiceDesc = grpc.ServiceDesc{
 		{
 			StreamName:    "PullImage",
 			Handler:       _Docker_PullImage_Handler,
+			ServerStreams: true,
+		},
+		{
+			StreamName:    "ContainerLogs",
+			Handler:       _Docker_ContainerLogs_Handler,
 			ServerStreams: true,
 		},
 	},

--- a/internal/machine/docker/client_logs.go
+++ b/internal/machine/docker/client_logs.go
@@ -1,0 +1,66 @@
+package docker
+
+import (
+	"context"
+	"errors"
+	"github.com/psviderski/uncloud/internal/machine/api/pb"
+	"io"
+)
+
+// ContainerLogsOptions specifies parameters for ContainerLogs
+type ContainerLogsOptions struct {
+	Follow     bool
+	Tail       int64
+	Timestamps bool
+	Since      string
+	Until      string
+	Details    bool
+}
+
+// ContainerLogEntry represents a single log entry from a container
+type ContainerLogEntry struct {
+	StreamType int32 // 1 = stdout, 2 = stderr
+	Message    string
+	Timestamp  string
+}
+
+// ContainerLogs returns a channel that streams log entries from the container
+func (c *Client) ContainerLogs(ctx context.Context, containerID string, opts ContainerLogsOptions) (<-chan ContainerLogEntry, error) {
+	req := &pb.ContainerLogsRequest{
+		ContainerId: containerID,
+		Follow:      opts.Follow,
+		Tail:        opts.Tail,
+		Timestamps:  opts.Timestamps,
+		Since:       opts.Since,
+		Until:       opts.Until,
+		Details:     opts.Details,
+	}
+
+	stream, err := c.grpcClient.ContainerLogs(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+
+	ch := make(chan ContainerLogEntry, 100)
+	go func() {
+		defer close(ch)
+		for {
+			resp, err := stream.Recv()
+			if err != nil {
+				if errors.Is(err, io.EOF) {
+					return
+				}
+				//TODO: There's probably an error to handle here, but I'd rather just ignore it. anyway the channel will be closed to EOF signal
+				return
+			}
+
+			ch <- ContainerLogEntry{
+				StreamType: resp.StreamType,
+				Message:    resp.Message,
+				Timestamp:  resp.Timestamp,
+			}
+		}
+	}()
+
+	return ch, nil
+}

--- a/internal/machine/docker/server.go
+++ b/internal/machine/docker/server.go
@@ -3,6 +3,7 @@ package docker
 import (
 	"context"
 	"database/sql"
+	"encoding/binary"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -852,4 +853,108 @@ func (s *Server) RemoveServiceContainer(ctx context.Context, req *pb.RemoveConta
 	}
 
 	return resp, nil
+}
+
+// ContainerLogs streams logs from a container
+func (s *Server) ContainerLogs(req *pb.ContainerLogsRequest, stream grpc.ServerStreamingServer[pb.ContainerLogsResponse]) error {
+	ctx := stream.Context()
+
+	// Build container logs options
+	opts := container.LogsOptions{
+		ShowStdout: true,
+		ShowStderr: true,
+		Follow:     req.Follow,
+		Timestamps: req.Timestamps,
+		Details:    req.Details,
+	}
+
+	// Handle tail option
+	if req.Tail > 0 {
+		opts.Tail = strconv.FormatInt(req.Tail, 10)
+	} else if req.Tail == 0 {
+		// Tail 0 means show no logs, just follow new ones
+		opts.Tail = "0"
+	}
+	// Tail -1 or unset means show all logs
+
+	// Handle since/until options
+	if req.Since != "" {
+		opts.Since = req.Since
+	}
+	if req.Until != "" {
+		opts.Until = req.Until
+	}
+
+	// Get logs reader from Docker
+	reader, err := s.client.ContainerLogs(ctx, req.ContainerId, opts)
+	if err != nil {
+		return status.Errorf(codes.Internal, "get container logs: %v", err)
+	}
+	defer reader.Close()
+
+	// Well, docker multiplexes stdout and stderr in the stream. Look https://github.com/moby/moby/blob/e77ff99ede5ee5952b3a9227863552ae6e5b6fb1/client/container_logs.go#L14-L36
+	// The stream format is: [8 bytes header][payload]
+	// Header format: [stream type (1 byte)][reserved (3 bytes)][size (4 bytes, big endian)]
+	buf := make([]byte, 8)
+
+	for {
+		// Read header
+		_, err := io.ReadFull(reader, buf)
+		if err != nil {
+			if err == io.EOF {
+				return nil
+			}
+			return status.Errorf(codes.Internal, "read log header: %v", err)
+		}
+
+		// Parse header
+		streamType := int32(buf[0])
+		size := binary.BigEndian.Uint32(buf[4:8])
+
+		// Read payload
+		payload := make([]byte, size)
+		_, err = io.ReadFull(reader, payload)
+		if err != nil {
+			return status.Errorf(codes.Internal, "read log payload: %v", err)
+		}
+
+		// convert payload to string and split by lines. docker may send multiple lines in one payload
+		lines := strings.Split(string(payload), "\n")
+		for _, line := range lines {
+			if line == "" {
+				continue
+			}
+
+			timestamp := ""
+			message := line
+			if req.Timestamps && len(line) > 30 {
+				// docker timestamp format: 2024-01-01T00:00:00.000000000Z
+				if line[4] == '-' && line[7] == '-' && line[10] == 'T' {
+					parts := strings.SplitN(line, " ", 2)
+					if len(parts) == 2 {
+						timestamp = parts[0]
+						message = parts[1]
+					}
+				}
+			}
+
+			// Send log entry
+			resp := &pb.ContainerLogsResponse{
+				StreamType: streamType,
+				Message:    message,
+				Timestamp:  timestamp,
+			}
+
+			if err := stream.Send(resp); err != nil {
+				return status.Errorf(codes.Internal, "send log entry: %v", err)
+			}
+		}
+
+		// Check if context is cancelled
+		select {
+		case <-ctx.Done():
+			return status.Errorf(codes.Canceled, ctx.Err().Error())
+		default:
+		}
+	}
 }


### PR DESCRIPTION
This PR implements the `uc logs` command for viewing aggregated logs from all containers of a service across the Uncloud cluster

## Part 0
  - New `uc logs <service>` command that aggregates logs from all service containers
  - Real-time streaming via gRPC from each machine in the cluster
  - Support for standard Docker log options: `--follow`, `--tail`, `--timestamps`, `--since`, `--until`


 Two Merge Models:
  - Fast mode (default): Logs are printed immediately as received
    - Minimal latency and resource usage
    - Best-effort ordering between machines
    - Suitable for common debugging
  - Strict ordering mode (`--strict-order` flag):
    - Guaranteed chronological order across all machines
    - Uses min-heap based k-way merge algorithm


### Commands
```bash
uncloud git:(feat/uncloud-logs) ./uc log --help

View logs from all replicas of a service.

The logs command retrieves and displays logs from all running replicas
of the specified service across all machines in the cluster.

Usage:
  uncloud logs SERVICE [flags]

Aliases:
  logs, log

Flags:
  -c, --context string   Name of the cluster context. (default is the current context)
  -f, --follow           Follow log output
  -h, --help             help for logs
      --since string     Show logs since timestamp or relative (42m for 42 minutes)
      --strict-order     Merge logs in strict chronological order (slower but accurate)
      --tail int         Number of lines to show from the end of the logs (default -1)
  -t, --timestamps       Show timestamps
      --until string     Show logs before a timestamp or relative (42m for 42 minutes)

Global Flags:
      --connect string          Connect to a remote cluster machine without using the Uncloud configuration file.
                                Format: [ssh://]user@host[:port] or tcp://host:port
      --uncloud-config string   Path to the Uncloud configuration file. (default "~/.config/uncloud/config.yaml")
```



### Examples
<details>
  <summary>Show details...</summary>
-  Show the last 5 lines of each replica
```bash
./uc log excalidraw --tail 5
```

> <img width="1017" height="301" alt="image" src="https://github.com/user-attachments/assets/0f4455a0-066c-45f2-a91f-b98469de56a1" />


- Show logs for the last 6 minutes
```bash
./uc log excalidraw --since 6m
```

> <img width="996" height="643" alt="image" src="https://github.com/user-attachments/assets/03268bd0-4abd-4015-9a32-1b959385ffdb" />

- Show the last 10 lines of each replica, and merge logs in strict chronological order (slower but accurate)
```bash
./uc log excalidraw -t --tail 10 --strict-order
```

> <img width="1134" height="542" alt="image" src="https://github.com/user-attachments/assets/b1e17f72-98ac-48a1-8046-e81f371fbda0" />

</details>



## Part 1 WIP
Implement a persistent log storage that saves container logs to disk on each machine, enabling access to historical logs even after containers are removed

related issue [#12 ](https://github.com/psviderski/uncloud/issues/12)