### PR TITLE
feat(deploy): Recreate container when pull_policy set to Always

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -101,10 +101,6 @@ lint-and-fix: ARGS=--fix
 _lint:
 	golangci-lint run $(ARGS)
 
-# .PHONY: lint-and-fix
-# lint-and-fix: lint
-# 	ARGS="--fix"
-
 .PHONY: docs-image-push
 docs-image:
 	docker buildx build --push --platform linux/amd64,linux/arm64 -t "$(DOCS_IMAGE)" ./docs

--- a/pkg/client/deploy/container.go
+++ b/pkg/client/deploy/container.go
@@ -26,7 +26,10 @@ func EvalContainerSpecChange(current api.ServiceSpec, new api.ServiceSpec) Conta
 		return ContainerNeedsRecreate
 	}
 
-	// Pull policy doesn't affect the container configuration.
+	// If pull policy is set to always, the container needs to be recreated.
+	if new.Container.PullPolicy == api.PullPolicyAlways {
+		return ContainerNeedsRecreate
+	}
 	new.Container.PullPolicy = current.Container.PullPolicy
 
 	// Save mutable container resources that can be updated without recreation.

--- a/pkg/client/deploy/container_test.go
+++ b/pkg/client/deploy/container_test.go
@@ -324,6 +324,54 @@ func TestEvalContainerSpecChange_ContainerPrivileged(t *testing.T) {
 	assert.Equal(t, ContainerNeedsRecreate, EvalContainerSpecChange(newSpec, currentSpec))
 }
 
+func TestEvalContainerSpecChange_PullPolicy(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		current string
+		new     string
+		want    ContainerSpecStatus
+	}{
+		{
+			name:    "non-always to always",
+			current: api.PullPolicyMissing,
+			new:     api.PullPolicyAlways,
+			want:    ContainerNeedsRecreate,
+		},
+		{
+			name:    "always to always",
+			current: api.PullPolicyAlways,
+			new:     api.PullPolicyAlways,
+			want:    ContainerNeedsRecreate,
+		},
+		{
+			name:    "always to non-always",
+			current: api.PullPolicyAlways,
+			new:     api.PullPolicyMissing,
+			want:    ContainerUpToDate,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			currentSpec := api.ServiceSpec{
+				Container: api.ContainerSpec{
+					PullPolicy: tt.current,
+				},
+			}
+			newSpec := api.ServiceSpec{
+				Container: api.ContainerSpec{
+					PullPolicy: tt.new,
+				},
+			}
+
+			result := EvalContainerSpecChange(currentSpec, newSpec)
+			assert.Equal(t, tt.want, result)
+		})
+	}
+}
+
 func TestEvalContainerSpecChange_ContainerUser(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Currently, when `pullPolicy` is set to `always` for a service, we don't redeploy the service on `uc deploy`.
This is problematic for e.g. situations when a floating reference (e.g. "xxx:latest") is used for `image`.

`docker compose up` respects `pullPolicy: always`: it pulls the image and recreates the container every time; I'd suggest we follow the same behavior.