### PR TITLE
Adding machine.service.internal dns entries

### DIFF
--- a/internal/machine/dns/resolver.go
+++ b/internal/machine/dns/resolver.go
@@ -42,7 +42,7 @@ func (r *ClusterResolver) Run(ctx context.Context) error {
 	r.log.Info("Subscribed to container changes in the cluster to keep DNS records updated.")
 
 	// TODO: implement machine membership check using Corrossion Admin client to filter available containers.
-	r.updateServiceIPs(containers)
+	r.updateServiceIPs(ctx, containers)
 
 	for {
 		select {
@@ -59,7 +59,7 @@ func (r *ClusterResolver) Run(ctx context.Context) error {
 			}
 
 			// TODO: implement machine membership check using Corrossion Admin client to filter available containers.
-			r.updateServiceIPs(containers)
+			r.updateServiceIPs(ctx, containers)
 		case <-ctx.Done():
 			return nil
 		}
@@ -67,7 +67,7 @@ func (r *ClusterResolver) Run(ctx context.Context) error {
 }
 
 // updateServiceIPs processes container records and updates the serviceIPs map.
-func (r *ClusterResolver) updateServiceIPs(containers []store.ContainerRecord) {
+func (r *ClusterResolver) updateServiceIPs(ctx context.Context, containers []store.ContainerRecord) {
 	newServiceIPs := make(map[string][]netip.Addr, len(r.serviceIPs))
 
 	containersCount := 0
@@ -91,6 +91,16 @@ func (r *ClusterResolver) updateServiceIPs(containers []store.ContainerRecord) {
 		newServiceIPs[ctr.ServiceName()] = append(newServiceIPs[ctr.ServiceName()], ip)
 		// Also add the service ID as a valid lookup.
 		newServiceIPs[ctr.ServiceID()] = append(newServiceIPs[ctr.ServiceID()], ip)
+
+		// Add <machine-name>.<service-name> as a lookup
+		machineInfo, err := r.store.GetMachine(ctx, record.MachineID)
+		if err != nil {
+			// @todo
+		} else {
+			serviceNameWithMachine := machineInfo.Name + "." + ctr.ServiceName()
+			newServiceIPs[serviceNameWithMachine] = append(newServiceIPs[serviceNameWithMachine], ip)
+		}
+
 		containersCount++
 	}
 


### PR DESCRIPTION
I have a use case where I want to connect to a service container running on a particular machine, and this adds an additional entry to the internal DNS service resolver with `machine-name.service-name` (in addition to the existing `service-name` and `service-id` entries).

This is just an initial, quick stab at the idea. I think it might be cleaner to retrieve machine name as part of the cluster store's containers subscribe/list functions with a join in its select instead:

```
select c.*, m.name as machine_name from containers c join machines m on c.machine_id = m.id;
```

And then pass that through the `ContainerRecord` they return and `internal/machine/dns/resolver.go` uses.

Anyway, I thought I'd get your input on this first before I go further with that. 

My use case is ultimately about needing to denote one machine as a "leader" for the service, and this approach seemed like something that could be generally useful (for myself and others). I could also accomplish this with two minor variants of the service, but that's a little more manual (needing to manage the `x-machines` for the followers).