### PR TITLE
Draft: Set machine id in service container ENV

### DIFF
--- a/internal/machine/docker/server.go
+++ b/internal/machine/docker/server.go
@@ -57,6 +57,9 @@ type Server struct {
 	// internalDNSIP is a function that returns the IP address of the internal DNS server. It may return an empty
 	// address if the address is unknown (e.g. when the machine is not initialised yet).
 	internalDNSIP func() netip.Addr
+	// machineID is a function that returns the machine ID. It may return an empty string if the machine
+	// is not initialised yet.
+	machineID func() string
 	// networkReady is a function that returns true if the Docker network is ready for containers.
 	networkReady func() bool
 	// waitForNetworkReady is a function that waits for the Docker network to be ready for containers.
@@ -72,12 +75,13 @@ type ServerOptions struct {
 }
 
 // NewServer creates a new Docker gRPC server with the provided Docker service.
-func NewServer(service *Service, db *sqlx.DB, internalDNSIP func() netip.Addr, opts ServerOptions) *Server {
+func NewServer(service *Service, db *sqlx.DB, internalDNSIP func() netip.Addr, machineID func() string, opts ServerOptions) *Server {
 	s := &Server{
 		client:        service.Client,
 		service:       service,
 		db:            db,
 		internalDNSIP: internalDNSIP,
+		machineID:     machineID,
 	}
 
 	s.networkReady = opts.NetworkReady
@@ -529,9 +533,19 @@ func (s *Server) CreateServiceContainer(
 		containerName = fmt.Sprintf("%s-%s", spec.Name, suffix)
 	}
 
+	// Start with the environment from the service spec
+	envVars := spec.Container.Env.ToSlice()
+
+	// Inject the machine ID if available
+	if s.machineID != nil {
+		if machineID := s.machineID(); machineID != "" {
+			envVars = append(envVars, "UNCLOUD_MACHINE_ID="+machineID)
+		}
+	}
+
 	config := &container.Config{
 		Cmd:        spec.Container.Command,
-		Env:        spec.Container.Env.ToSlice(),
+		Env:        envVars,
 		Entrypoint: spec.Container.Entrypoint,
 		Hostname:   containerName,
 		Image:      spec.Container.Image,

--- a/internal/machine/machine.go
+++ b/internal/machine/machine.go
@@ -282,7 +282,11 @@ func NewMachine(config *Config) (*Machine, error) {
 	internalDNSIP := func() netip.Addr {
 		return m.IP()
 	}
-	m.dockerServer = machinedocker.NewServer(dockerService, db, internalDNSIP, machinedocker.ServerOptions{
+	// Machine ID will only be available after the machine is initialised as a cluster member so wrap it in a function.
+	machineID := func() string {
+		return m.state.ID
+	}
+	m.dockerServer = machinedocker.NewServer(dockerService, db, internalDNSIP, machineID, machinedocker.ServerOptions{
 		NetworkReady:        m.IsNetworkReady,
 		WaitForNetworkReady: m.WaitForNetworkReady,
 	})


### PR DESCRIPTION
Just a draft of the idea, but I was thinking about how to expose info like the current machine ID to the services running on it. This is passing it in via the ENV.

Some thoughts:
1. I'm not entirely positive that it needs the callback approach to get the id here (like it does with the IP), but it _seemed_ like it was possible the machine ID would not be available yet when it was new a new machine still be initialized.

2. Are there other bits of info like machine ID that would be useful, and if so, would the ENV approach work for them to?
- service id?
- public IP (maybe wireguard IP -- not sure if useful?), but not sure if that is too dynamic/could change during lifetime of the instance

3. Is there a better way to do this than ENV? I currently solve this by writing a file with the machine id to a host file on each machine that is mounted into the service for it to read. Maybe something similar, but built-in to uncloud, would be a better approach.



