### PR TITLE
Fix progress percent overflow in image push

### DIFF
--- a/pkg/client/image.go
+++ b/pkg/client/image.go
@@ -472,6 +472,11 @@ func toPushProgressEvent(jm jsonmessage.JSONMessage) *progress.Event {
 
 	if jm.Progress.Total > 0 {
 		percent = int(jm.Progress.Current * 100 / jm.Progress.Total)
+		// Cap percent at 100 to prevent index out of bounds in progress display.
+		// Docker can report Current > Total in some cases (e.g., compression).
+		if percent > 100 {
+			percent = 100
+		}
 	}
 
 	switch jm.Status {


### PR DESCRIPTION
On certain scenarios, Docker will report a bigger Current than Total, resulting in an overflow when trying to show the progress of the push for the image.

Cap progress percentage at 100 to prevent index out of bounds errors in progress display, as sometimes the calculation could exceed 100.