### PR TITLE
feat: [draft] Add name property to config connections for use in `--connect {name}` option

### DIFF
--- a/cmd/uncloud/machine/rename.go
+++ b/cmd/uncloud/machine/rename.go
@@ -42,6 +42,20 @@ func rename(ctx context.Context, uncli *cli.CLI, contextName, oldName, newName s
 		return fmt.Errorf("rename machine: %w", err)
 	}
 
+	// Update the machine name in the config file.
+	if uncli.Config != nil {
+		context := uncli.Config.Contexts[uncli.Config.CurrentContext]
+		for i, c := range context.Connections {
+			if c.Name == oldName {
+				context.Connections[i].Name = newName
+				break
+			}
+		}
+		if err := uncli.Config.Save(); err != nil {
+			return fmt.Errorf("save config: %w", err)
+		}
+	}
+
 	fmt.Printf("Machine %q renamed to %q (ID: %s)\n", oldName, machine.Name, machine.Id)
 	return nil
 }

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -398,6 +398,7 @@ func (cli *CLI) AddMachine(ctx context.Context, opts AddMachineOptions) (*client
 	connCfg := config.MachineConnection{
 		SSH:        config.NewSSHDestination(opts.RemoteMachine.User, opts.RemoteMachine.Host, opts.RemoteMachine.Port),
 		SSHKeyFile: opts.RemoteMachine.KeyPath,
+		Name:       opts.MachineName,
 	}
 	if contextName == "" {
 		contextName = cli.Config.CurrentContext

--- a/internal/cli/config/connection.go
+++ b/internal/cli/config/connection.go
@@ -25,16 +25,30 @@ type MachineConnection struct {
 	TCP       *netip.AddrPort `yaml:"tcp,omitempty"`
 	Host      string          `yaml:"host,omitempty"`
 	PublicKey secret.Secret   `yaml:"public_key,omitempty"`
+	Name      string          `yaml:"name,omitempty"`
 }
 
 func (c MachineConnection) String() string {
+	var connStr string
 	if c.SSH != "" {
-		return "ssh://" + string(c.SSH)
+		connStr = "ssh://" + string(c.SSH)
 	} else if c.SSHCLI != "" {
-		return "ssh+cli://" + string(c.SSHCLI)
+		connStr = "ssh+cli://" + string(c.SSHCLI)
 	} else if c.TCP != nil && c.TCP.IsValid() {
-		return fmt.Sprintf("tcp://%s", c.TCP)
+		connStr = fmt.Sprintf("tcp://%s", c.TCP)
 	}
+
+	if c.Name != "" {
+		if connStr != "" {
+			return fmt.Sprintf("%s (%s)", c.Name, connStr)
+		}
+		return c.Name
+	}
+
+	if connStr != "" {
+		return connStr
+	}
+
 	return "unknown connection"
 }
 


### PR DESCRIPTION
Adds an alias to the connections config to use in `--connect` option.

It also stores the name with the connection info when adding a machine, updates the name when renaming the machine, and removes the connection entry by name when removing the machine.

Just cli changes which are working for me locally in `--connect` usage, but I have not testing the add/rename/remove bit. (We could remove the auto-update parts for an initial version, too. Even just being able to add manual names/labels is pretty convenient on its own.)