### PR TITLE
feat: Allow container matching by ID prefix

### DIFF
--- a/cmd/uncloud/service/exec.go
+++ b/cmd/uncloud/service/exec.go
@@ -28,7 +28,7 @@ func NewExecCommand() *cobra.Command {
 		Use:   "exec [OPTIONS] SERVICE [COMMAND ARGS...]",
 		Short: "Execute a command in a running service container",
 		Long: `Execute a command (interactive shell by default) in a running container within a service.
-If the service has multiple replicas, the command will be executed in a random container.
+If the service has multiple replicas and no container ID is specified, the command will be executed in a random container.
 	`,
 		Example: `
   # Start an interactive shell ("bash" or "sh" will be tried by default)
@@ -37,8 +37,8 @@ If the service has multiple replicas, the command will be executed in a random c
   # Start an interactive shell with explicit command
   uc exec web-service /bin/zsh
 
-  # List files in the specific container of the service
-  uc exec --container d792ea7347e5 web-service ls -la
+  # List files in the specific container of the service; --container accepts full ID or a (unique) prefix
+  uc exec --container d792e web-service ls -la
 
   # Pipe input to a command inside the service container
   cat backup.sql | uc exec -T db-service psql -U postgres mydb

--- a/test/e2e/exec_test.go
+++ b/test/e2e/exec_test.go
@@ -224,7 +224,8 @@ func TestExecBasicCommands(t *testing.T) {
 
 		var stdout, stderr bytes.Buffer
 
-		containerID := service.Containers[1].Container.ID
+		// Use container prefix
+		containerIDPrefix := service.Containers[1].Container.ID[:3]
 		execOptions := api.ExecOptions{
 			Command:      []string{"hostname"},
 			AttachStdout: true,
@@ -233,7 +234,7 @@ func TestExecBasicCommands(t *testing.T) {
 			Stderr:       &stderr,
 		}
 
-		exitCode, err := cli.ExecContainer(ctx, multiServiceName, containerID, execOptions)
+		exitCode, err := cli.ExecContainer(ctx, multiServiceName, containerIDPrefix, execOptions)
 
 		require.NoError(t, err)
 		assert.Equal(t, 0, exitCode)

--- a/website/docs/9-cli-reference/uc_exec.md
+++ b/website/docs/9-cli-reference/uc_exec.md
@@ -5,7 +5,7 @@ Execute a command in a running service container
 ## Synopsis
 
 Execute a command (interactive shell by default) in a running container within a service.
-If the service has multiple replicas, the command will be executed in a random container.
+If the service has multiple replicas and no container ID is specified, the command will be executed in a random container.
 	
 
 ```
@@ -22,8 +22,8 @@ uc exec [OPTIONS] SERVICE [COMMAND ARGS...] [flags]
   # Start an interactive shell with explicit command
   uc exec web-service /bin/zsh
 
-  # List files in the specific container of the service
-  uc exec --container d792ea7347e5 web-service ls -la
+  # List files in the specific container of the service; --container accepts full ID or a (unique) prefix
+  uc exec --container d792e web-service ls -la
 
   # Pipe input to a command inside the service container
   cat backup.sql | uc exec -T db-service psql -U postgres mydb

--- a/website/docs/9-cli-reference/uc_service_exec.md
+++ b/website/docs/9-cli-reference/uc_service_exec.md
@@ -5,7 +5,7 @@ Execute a command in a running service container
 ## Synopsis
 
 Execute a command (interactive shell by default) in a running container within a service.
-If the service has multiple replicas, the command will be executed in a random container.
+If the service has multiple replicas and no container ID is specified, the command will be executed in a random container.
 	
 
 ```
@@ -22,8 +22,8 @@ uc service exec [OPTIONS] SERVICE [COMMAND ARGS...] [flags]
   # Start an interactive shell with explicit command
   uc exec web-service /bin/zsh
 
-  # List files in the specific container of the service
-  uc exec --container d792ea7347e5 web-service ls -la
+  # List files in the specific container of the service; --container accepts full ID or a (unique) prefix
+  uc exec --container d792e web-service ls -la
 
   # Pipe input to a command inside the service container
   cat backup.sql | uc exec -T db-service psql -U postgres mydb


### PR DESCRIPTION
Extends `Client.InspectContainer` to support prefix ID matching.

Should be at least applicable for:
* `uc exec --container XYZ ...`
* (future) `uc logs`
