### PR TITLE
refactor: Simplify dns e2e test using new ExecContainer functionality

### DIFF
--- a/test/e2e/dns_test.go
+++ b/test/e2e/dns_test.go
@@ -121,7 +121,7 @@ func TestInternalDNS(t *testing.T) {
 	}
 
 	t.Run("service name resolves to all container IPs", func(t *testing.T) {
-		dnsOutput := runNslookup(t, serviceName + ".internal")
+		dnsOutput := runNslookup(t, serviceName+".internal")
 		t.Logf("DNS query output:\n%s", dnsOutput)
 
 		// Verify that all service container IPs are in the DNS response
@@ -167,7 +167,7 @@ func TestInternalDNS(t *testing.T) {
 
 	t.Run("service ID DNS lookup", func(t *testing.T) {
 		// Test that service ID also resolves (existing functionality)
-		dnsOutput := runNslookup(t, svc.ID + ".internal")
+		dnsOutput := runNslookup(t, svc.ID+".internal")
 		t.Logf("Service ID DNS query output:\n%s", dnsOutput)
 
 		// Verify that all service container IPs are in the DNS response


### PR DESCRIPTION
The DNS e2e tests required a convoluted process of launching a new query service for each test that wrote nslookup output to a file in host-mounted volume that we then read from the ucind container.

With the new ExecContainer functionality, that can be simplified to an effective `uc exec dns-query-service nslookup {...}` where we can read the output directly.