### PR TITLE
fix: Extract version from latest redirect in install_cli.sh

### DIFF
--- a/scripts/install_cli.sh
+++ b/scripts/install_cli.sh
@@ -20,12 +20,8 @@ print_manual_install() {
 }
 
 fetch_latest_version() {
-    api_url="https://api.github.com/repos/${GITHUB_REPO}/releases/latest"
-    auth_header=""
-    if [ -n "$GITHUB_TOKEN" ]; then
-        auth_header="Authorization: Bearer $GITHUB_TOKEN"
-    fi
-    VERSION=$(curl -fsSL -H "$auth_header" "$api_url" | grep -o '"tag_name": "[^"]*' | cut -d'"' -f4)
+    latest_url="https://github.com/${GITHUB_REPO}/releases/latest"
+    VERSION=$(curl -fsSLI -o /dev/null -w '%{url_effective}' "$latest_url" | grep -o 'tag/[^/]*$' | cut -d'/' -f2)
     if [ -z "$VERSION" ]; then
         echo "Failed to fetch the latest version from GitHub."
         print_manual_install


### PR DESCRIPTION
Should resolve #163 by using the latest redirect which does not require authentication.