### PR TITLE
[spike] refactor/feat: Abstract cli table rendering and add JSON output format

### DIFF
--- a/cmd/uncloud/machine/ls.go
+++ b/cmd/uncloud/machine/ls.go
@@ -4,29 +4,43 @@ import (
 	"context"
 	"fmt"
 	"net/netip"
-	"os"
 	"strings"
-	"text/tabwriter"
 
 	"github.com/psviderski/uncloud/internal/cli"
+	"github.com/psviderski/uncloud/internal/cli/output"
 	"github.com/psviderski/uncloud/internal/machine/network"
 	"github.com/spf13/cobra"
 )
 
+type listOptions struct {
+	format string
+}
+
 func NewListCommand() *cobra.Command {
+	opts := listOptions{}
 	cmd := &cobra.Command{
 		Use:     "ls",
 		Aliases: []string{"list"},
 		Short:   "List machines in a cluster.",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			uncli := cmd.Context().Value("cli").(*cli.CLI)
-			return list(cmd.Context(), uncli)
+			return list(cmd.Context(), uncli, opts)
 		},
 	}
+	cmd.Flags().StringVar(&opts.format, "format", "table", "Output format (table, json)")
 	return cmd
 }
 
-func list(ctx context.Context, uncli *cli.CLI) error {
+type machineItem struct {
+	Name               string   `json:"name"`
+	State              string   `json:"state"`
+	Address            string   `json:"address"`
+	PublicIP           *string  `json:"publicIp"`
+	WireGuardEndpoints []string `json:"wireguardEndpoints"`
+	MachineID          string   `json:"machineId"`
+}
+
+func list(ctx context.Context, uncli *cli.CLI, opts listOptions) error {
 	client, err := uncli.ConnectCluster(ctx)
 	if err != nil {
 		return fmt.Errorf("connect to cluster: %w", err)
@@ -38,22 +52,17 @@ func list(ctx context.Context, uncli *cli.CLI) error {
 		return fmt.Errorf("list machines: %w", err)
 	}
 
-	// Print the list of machines in a table format.
-	tw := tabwriter.NewWriter(os.Stdout, 0, 0, 3, ' ', 0)
-	// Print header.
-	if _, err = fmt.Fprintln(tw, "NAME\tSTATE\tADDRESS\tPUBLIC IP\tWIREGUARD ENDPOINTS\tMACHINE ID"); err != nil {
-		return fmt.Errorf("write header: %w", err)
-	}
-	// Print rows.
+	var items []machineItem
 	for _, member := range machines {
 		m := member.Machine
 		subnet, _ := m.Network.Subnet.ToPrefix()
 		subnet = netip.PrefixFrom(network.MachineIP(subnet), subnet.Bits())
 
-		publicIP := "-"
+		var publicIP *string
 		if m.PublicIp != nil {
 			ip, _ := m.PublicIp.ToAddr()
-			publicIP = ip.String()
+			s := ip.String()
+			publicIP = &s
 		}
 
 		endpoints := make([]string, len(m.Network.Endpoints))
@@ -62,14 +71,31 @@ func list(ctx context.Context, uncli *cli.CLI) error {
 			endpoints[i] = addrPort.String()
 		}
 
-		if _, err = fmt.Fprintf(
-			tw, "%s\t%s\t%s\t%s\t%s\t%s\n", m.Name, capitalise(member.State.String()), subnet, publicIP,
-			strings.Join(endpoints, ", "), member.Machine.Id,
-		); err != nil {
-			return fmt.Errorf("write row: %w", err)
-		}
+		items = append(items, machineItem{
+			Name:               m.Name,
+			State:              member.State.String(),
+			Address:            subnet.String(),
+			PublicIP:           publicIP,
+			WireGuardEndpoints: endpoints,
+			MachineID:          m.Id,
+		})
 	}
-	return tw.Flush()
+
+	columns := []output.Column[machineItem]{
+		{Header: "NAME", Field: "Name"},
+		{
+			Header: "STATE",
+			Accessor: func(r machineItem) string {
+				return capitalise(r.State)
+			},
+		},
+		{Header: "ADDRESS", Field: "Address"},
+		{Header: "PUBLIC IP", Field: "PublicIP"},
+		{Header: "WIREGUARD ENDPOINTS", Field: "WireGuardEndpoints"},
+		{Header: "MACHINE ID", Field: "MachineID"},
+	}
+
+	return output.Print(items, columns, opts.format)
 }
 
 // capitalise returns a string where the first character is upper case, and the rest is lower case.

--- a/internal/cli/output/output.go
+++ b/internal/cli/output/output.go
@@ -1,0 +1,151 @@
+package output
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"reflect"
+	"strings"
+
+	"github.com/charmbracelet/lipgloss"
+	"github.com/charmbracelet/lipgloss/table"
+	"github.com/muesli/termenv"
+)
+
+// Column defines how to render a specific field from the data for the Table view.
+type Column[T any] struct {
+	// Header is the column title.
+	Header string
+	// Accessor extracts the value from the row object and formats it for the table.
+	// If Accessor is provided, it takes precedence over Field.
+	Accessor func(row T) string
+	// Field is the name of the struct field to extract value from.
+	// It is used if Accessor is nil.
+	Field string
+}
+
+// Print renders the data in the requested format.
+// data: must be a slice of structs (e.g., []Image, []Machine) for "table" format,
+// or any JSON-marshalable object for "json" format.
+// format: "table" or "json" (default is "table").
+func Print[T any](data any, columns []Column[T], format string) error {
+	switch format {
+	case "json":
+		return printJSON(data)
+	default:
+		return printTable(data, columns)
+	}
+}
+
+func printJSON(data any) error {
+	encoder := json.NewEncoder(os.Stdout)
+	encoder.SetIndent("", "  ")
+	return encoder.Encode(data)
+}
+
+func printTable[T any](data any, columns []Column[T]) error {
+	// Use reflection to verify data is a slice and iterate over it.
+	v := reflect.ValueOf(data)
+	if v.Kind() != reflect.Slice {
+		return fmt.Errorf("output.Print: data must be a slice, got %T", data)
+	}
+
+	// 1. Setup Lipgloss Table
+	t := table.New().
+		Border(lipgloss.Border{}).
+		BorderTop(false).
+		BorderBottom(false).
+		BorderLeft(false).
+		BorderRight(false).
+		BorderHeader(false).
+		BorderColumn(false).
+		StyleFunc(func(row, col int) lipgloss.Style {
+			if row == table.HeaderRow {
+				return lipgloss.NewStyle().Bold(true).PaddingRight(3)
+			}
+			// Regular style for data rows with padding.
+			return lipgloss.NewStyle().PaddingRight(3)
+		})
+
+	// 2. Add Headers
+	var headers []string
+	for _, col := range columns {
+		headers = append(headers, col.Header)
+	}
+	t.Headers(headers...)
+
+	// 3. Add Rows
+	for i := 0; i < v.Len(); i++ {
+		rowItem := v.Index(i).Interface().(T)
+		var rowStrings []string
+		for _, col := range columns {
+			val := getValue(rowItem, col)
+			rowStrings = append(rowStrings, val)
+		}
+		t.Row(rowStrings...)
+	}
+
+	// 4. Print
+	if v.Len() == 0 {
+		return nil
+	}
+	fmt.Println(t.String())
+	return nil
+}
+
+func getValue[T any](row T, col Column[T]) string {
+	if col.Accessor != nil {
+		return col.Accessor(row)
+	}
+
+	if col.Field == "" {
+		return ""
+	}
+
+	v := reflect.ValueOf(row)
+	// If it's a pointer, dereference it
+	if v.Kind() == reflect.Ptr {
+		v = v.Elem()
+	}
+
+	f := v.FieldByName(col.Field)
+	if !f.IsValid() {
+		return ""
+	}
+
+	// Handle pointers
+	if f.Kind() == reflect.Ptr {
+		if f.IsNil() {
+			return "-"
+		}
+		f = f.Elem()
+	}
+
+	switch f.Kind() {
+	case reflect.Slice:
+		if f.Type().Elem().Kind() == reflect.String {
+			// Handle []string
+			var parts []string
+			for i := 0; i < f.Len(); i++ {
+				parts = append(parts, fmt.Sprint(f.Index(i).Interface()))
+			}
+			return strings.Join(parts, ", ")
+		}
+		return fmt.Sprint(f.Interface())
+	default:
+		return fmt.Sprint(f.Interface())
+	}
+}
+
+// PillStyle returns a standard style for "pills" (like platform tags).
+func PillStyle() lipgloss.Style {
+	style := lipgloss.NewStyle().
+		BorderForeground(lipgloss.Color("152")).
+		Foreground(lipgloss.Color("0")).
+		Background(lipgloss.Color("152"))
+
+	if lipgloss.ColorProfile() != termenv.Ascii {
+		style = style.Border(lipgloss.Border{Left: "", Right: ""}, false, true, false, true)
+	}
+	return style
+}


### PR DESCRIPTION
An AI generated draft of the table refactor with JSON output format idea. https://github.com/psviderski/uncloud/pull/165#discussion_r2553567779

Not sure how I feel about the overall implementation it took here, but it seemed like a useful draft to start a conversation on how we want to do it.

In brief, this approach is basically "JSON-first" now, generating structs that are more or less directly output for the JSON "format" and then the standard TUI table format is just defining column->field map with optional transforms, like "-" for nil, humanized times, etc. 

It also uses lipgloss table for everything now, rather than tabwriter. Not sure if there's any reason to not... do we want to keep tabwriter for some commands? Or as another output option (a simpler, non-styled version)?