### PR TITLE
feat(uc/caddy): expose 443/udp port for HTTP3

### DIFF
--- a/pkg/client/caddy.go
+++ b/pkg/client/caddy.go
@@ -71,6 +71,7 @@ func (cli *Client) NewCaddyDeployment(image, config string, placement api.Placem
 				Protocol:      api.ProtocolTCP,
 				Mode:          api.PortModeHost,
 			},
+			// Needed for HTTP/3 (QUIC)
 			{
 				PublishedPort: 443,
 				ContainerPort: 443,


### PR DESCRIPTION
Next to TCP 443 also expose UDP 443 port so that caddy can accept HTTP3 connections. HTTP3 is enabled by default in Caddy.