### PR TITLE
fix: volume driver options are not used if driver if not specified

### DIFF
--- a/pkg/client/compose/service.go
+++ b/pkg/client/compose/service.go
@@ -249,7 +249,7 @@ func dockerVolumeSpecFromCompose(serviceVolume types.ServiceVolumeConfig, volume
 	}
 
 	if !volume.External {
-		if volume.Driver != "" {
+		if volume.Driver != "" || len(volume.DriverOpts) > 0 {
 			spec.VolumeOptions.Driver = &mount.Driver{
 				Name:    volume.Driver,
 				Options: volume.DriverOpts,


### PR DESCRIPTION
Fix for bug #210

Volume `driver_opts` are not being used if the `driver` is not specified.