### PR TITLE
fix: Set volume driver name to "local" if not specified

### DIFF
--- a/pkg/api/volume.go
+++ b/pkg/api/volume.go
@@ -83,6 +83,9 @@ func (v *VolumeSpec) SetDefaults() VolumeSpec {
 		if spec.VolumeOptions.Name == "" {
 			spec.VolumeOptions.Name = spec.Name
 		}
+		if spec.VolumeOptions.Driver != nil && spec.VolumeOptions.Driver.Name == "" {
+			spec.VolumeOptions.Driver.Name = VolumeDriverLocal
+		}
 	}
 	// TODO: set explicit default values for Propagation and Recursive for bind mounts?
 

--- a/pkg/api/volume_test.go
+++ b/pkg/api/volume_test.go
@@ -1,0 +1,68 @@
+package api
+
+import (
+	"testing"
+
+	"github.com/docker/docker/api/types/mount"
+	"github.com/docker/docker/api/types/volume"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestVolumeSpec_MatchesDockerVolume(t *testing.T) {
+	tests := []struct {
+		name     string
+		spec     VolumeSpec
+		vol      volume.Volume
+		expected bool
+	}{
+		{
+			name: "match with explicit local driver",
+			spec: VolumeSpec{
+				Type: VolumeTypeVolume,
+				VolumeOptions: &VolumeOptions{
+					Driver: &mount.Driver{
+						Name: "local",
+						Options: map[string]string{
+							"foo": "bar",
+						},
+					},
+				},
+			},
+			vol: volume.Volume{
+				Driver: "local",
+				Options: map[string]string{
+					"foo": "bar",
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "match with empty driver name in spec (implicit local)",
+			spec: VolumeSpec{
+				Type: VolumeTypeVolume,
+				VolumeOptions: &VolumeOptions{
+					Driver: &mount.Driver{
+						Name: "", // Implicitly local
+						Options: map[string]string{
+							"foo": "bar",
+						},
+					},
+				},
+			},
+			vol: volume.Volume{
+				Driver: "local",
+				Options: map[string]string{
+					"foo": "bar",
+				},
+			},
+			expected: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			matches := tt.spec.MatchesDockerVolume(tt.vol)
+			assert.Equal(t, tt.expected, matches)
+		})
+	}
+}


### PR DESCRIPTION
`MatchesDockerVolume` returns a error when volume driver name is blank versus "local".

Not certain this is the right fix, but I'm updating the volumes `SetDefaults` to set the driver name to "local" if not set.

<img width="1477" height="42" alt="volume-mismatch-error" src="https://github.com/user-attachments/assets/c57b8565-bad2-48d0-b3c1-d8ef5dde6ee9" />

https://discord.com/channels/1371726032104587335/1371726032838594565/1449615928185720895