### PR TITLE
Add `depends_on: service_healthy` condition support

### DIFF
--- a/cmd/uncloud/deploy.go
+++ b/cmd/uncloud/deploy.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"maps"
+	"slices"
 	"strings"
 
 	"github.com/charmbracelet/lipgloss"
@@ -204,8 +206,9 @@ func printPlan(ctx context.Context, cli *client.Client, plan *compose.Plan) erro
 		fmt.Println("- " + op.Format(nil))
 	}
 
-	// Print service plans.
-	for _, svcPlan := range plan.ServicePlans {
+	// Print service plans in sorted order for consistent output.
+	for _, name := range slices.Sorted(maps.Keys(plan.ServicePlans)) {
+		svcPlan := plan.ServicePlans[name]
 		if len(svcPlan.Operations) == 0 {
 			continue // skip no-op services
 		}

--- a/internal/machine/docker/server.go
+++ b/internal/machine/docker/server.go
@@ -564,6 +564,15 @@ func (s *Server) CreateServiceContainer(
 		},
 		User: spec.Container.User,
 	}
+	if spec.Container.Healthcheck != nil {
+		config.Healthcheck = &container.HealthConfig{
+			Test:        spec.Container.Healthcheck.Test,
+			Interval:    spec.Container.Healthcheck.Interval,
+			Timeout:     spec.Container.Healthcheck.Timeout,
+			Retries:     spec.Container.Healthcheck.Retries,
+			StartPeriod: spec.Container.Healthcheck.StartPeriod,
+		}
+	}
 	if spec.Mode == "" {
 		config.Labels[api.LabelServiceMode] = api.ServiceModeReplicated
 	}

--- a/pkg/api/service.go
+++ b/pkg/api/service.go
@@ -335,10 +335,7 @@ func (s *ContainerSpec) Clone() ContainerSpec {
 	}
 	if s.Healthcheck != nil {
 		hc := *s.Healthcheck
-		if s.Healthcheck.Test != nil {
-			hc.Test = make([]string, len(s.Healthcheck.Test))
-			copy(hc.Test, s.Healthcheck.Test)
-		}
+		hc.Test = slices.Clone(s.Healthcheck.Test)
 		spec.Healthcheck = &hc
 	}
 	if s.LogDriver != nil {

--- a/pkg/api/service.go
+++ b/pkg/api/service.go
@@ -403,11 +403,11 @@ type LogDriver struct {
 
 // HealthcheckConfig defines the health check configuration for a container.
 type HealthcheckConfig struct {
-	Test        []string      `json:"test,omitempty"`
-	Interval    time.Duration `json:"interval,omitempty"`
-	Timeout     time.Duration `json:"timeout,omitempty"`
-	Retries     int           `json:"retries,omitempty"`
-	StartPeriod time.Duration `json:"startPeriod,omitempty"`
+	Test        []string      `json:",omitempty"`
+	Interval    time.Duration `json:",omitempty"`
+	Timeout     time.Duration `json:",omitempty"`
+	Retries     int           `json:",omitempty"`
+	StartPeriod time.Duration `json:",omitempty"`
 }
 
 type RunServiceResponse struct {

--- a/pkg/client/compose/service.go
+++ b/pkg/client/compose/service.go
@@ -128,14 +128,9 @@ func ServiceSpecFromCompose(project *types.Project, serviceName string) (api.Ser
 
 // healthcheckFromCompose converts a compose HealthCheckConfig to api.HealthcheckConfig.
 func healthcheckFromCompose(hc *types.HealthCheckConfig) *api.HealthcheckConfig {
-	if hc == nil {
-		return nil
-	}
-
 	config := &api.HealthcheckConfig{
 		Test: hc.Test,
 	}
-
 	if hc.Interval != nil {
 		config.Interval = time.Duration(*hc.Interval)
 	}
@@ -148,7 +143,6 @@ func healthcheckFromCompose(hc *types.HealthCheckConfig) *api.HealthcheckConfig 
 	if hc.StartPeriod != nil {
 		config.StartPeriod = time.Duration(*hc.StartPeriod)
 	}
-
 	return config
 }
 

--- a/test/e2e/compose_configs_test.go
+++ b/test/e2e/compose_configs_test.go
@@ -39,7 +39,7 @@ func TestComposeConfigs(t *testing.T) {
 
 		plan, err := deploy.Plan(ctx)
 		require.NoError(t, err)
-		assert.Len(t, plan.Operations, 1, "Expected 1 service deployment")
+		assert.Equal(t, 1, plan.OperationCount(), "Expected 1 service deployment")
 
 		err = deploy.Run(ctx)
 		require.NoError(t, err)
@@ -93,7 +93,7 @@ func TestComposeConfigs(t *testing.T) {
 
 		plan, err = deploy.Plan(ctx)
 		require.NoError(t, err)
-		assert.Len(t, plan.Operations, 0, "Expected no new operations after configs deployment")
+		assert.Equal(t, 0, plan.OperationCount(), "Expected no new operations after configs deployment")
 
 		// Verify the config files are actually created in the container and contain expected content
 		containerName := svc.Containers[0].Container.Name

--- a/test/e2e/compose_deploy_test.go
+++ b/test/e2e/compose_deploy_test.go
@@ -564,15 +564,10 @@ func TestComposeDeployment(t *testing.T) {
 
 		// Wait for db service to be running (but not yet healthy).
 		var dbSvc api.Service
-		for i := 0; i < 30; i++ {
+		require.Eventually(t, func() bool {
 			dbSvc, err = cli.InspectService(ctx, "test-depends-db")
-			if err == nil && len(dbSvc.Containers) > 0 && dbSvc.Containers[0].Container.State.Running {
-				break
-			}
-			time.Sleep(time.Second)
-		}
-		require.NoError(t, err, "db service not found")
-		require.NotEmpty(t, dbSvc.Containers, "db service has no containers")
+			return err == nil && len(dbSvc.Containers) > 0 && dbSvc.Containers[0].Container.State.Running
+		}, 30*time.Second, time.Second, "db service should be running")
 
 		// Record the time before triggering health.
 		healthTriggerTime := time.Now()

--- a/test/e2e/fixtures/compose-depends-on.yaml
+++ b/test/e2e/fixtures/compose-depends-on.yaml
@@ -1,0 +1,18 @@
+services:
+  # DB service with manual healthcheck trigger
+  test-depends-db:
+    image: busybox
+    command: ["sleep", "infinity"]
+    healthcheck:
+      test: ["CMD", "test", "-f", "/tmp/healthy"]
+      interval: 1s
+      timeout: 5s
+      retries: 60
+      start_period: 0s
+
+  # App that waits for db to be healthy
+  test-depends-app:
+    image: portainer/pause:3.9
+    depends_on:
+      test-depends-db:
+        condition: service_healthy

--- a/website/docs/8-compose-file-reference/1-support-matrix.md
+++ b/website/docs/8-compose-file-reference/1-support-matrix.md
@@ -12,13 +12,14 @@ The following table shows the support status for main Compose features:
 | `command`          | ✅ Supported        | Override container command                                                                     |
 | `configs`          | ✅ Supported        | File-based and inline configs                                                                  |
 | `cpus`             | ✅ Supported        | CPU limit                                                                                      |
-| `depends_on`       | ⚠️ Limited         | Services deployed in order but conditions not checked                                          |
+| `depends_on`       | ⚠️ Limited         | `service_started` and `service_healthy` only                                                   |
 | `dns`              | ❌ Not supported    | Built-in service discovery                                                                     |
 | `dns_search`       | ❌ Not supported    | Built-in service discovery                                                                     |
 | `entrypoint`       | ✅ Supported        | Override container entrypoint                                                                  |
 | `env_file`         | ✅ Supported        | Environment file                                                                               |
 | `environment`      | ✅ Supported        | Environment variables                                                                          |
 | `gpus`             | ✅ Supported        | GPU device access                                                                              |
+| `healthcheck`      | ✅ Supported        | Container health check configuration                                                           |
 | `image`            | ✅ Supported        | Container image specification                                                                  |
 | `init`             | ✅ Supported        | Run init process in container                                                                  |
 | `labels`           | ❌ Not supported    |                                                                                                |


### PR DESCRIPTION
  - Add health check config support from compose files
  - Add `depends_on` with `condition: service_healthy` support
  - Deploy services in dependency order, waiting for health checks between dependent services

  ### Changes
  - `HealthcheckConfig` type in `api.ContainerSpec`
  - `compose.Plan` struct that handles dependency-ordered deployment with health waits
  - Health check config passed through to Docker container creation
  - 5 minute default health timeout

  ### Not yet supported
  - `condition: service_completed_successfully` (requires restart policy support)

  ### Testing
  - E2E test added that verifies dependent service starts only after health check passes