### PR TITLE
fix(configs): Create non-existent parent directories automatically

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,8 @@
 *.dll
 *.so
 *.dylib
+/uncloud
+/uncloudd
 
 # OS X
 .DS_Store

--- a/test/e2e/compose_configs_test.go
+++ b/test/e2e/compose_configs_test.go
@@ -66,6 +66,11 @@ func TestComposeConfigs(t *testing.T) {
 						Gid:           "1000",
 						Mode:          func() *os.FileMode { m := os.FileMode(0o600); return &m }(),
 					},
+					{
+						ConfigName:    "from-file",
+						ContainerPath: "/etc/new-dir/config-from-file.conf",
+						Mode:          func() *os.FileMode { m := os.FileMode(0o644); return &m }(),
+					},
 				},
 			},
 			Configs: []api.ConfigSpec{
@@ -110,5 +115,14 @@ func TestComposeConfigs(t *testing.T) {
 			userId:      1000,
 			groupId:     1000,
 		}, configContentSecond)
+
+		configContentThird, err := readFileInfoInContainer(t, cli, name, containerName, "/etc/new-dir/config-from-file.conf")
+		require.NoError(t, err)
+		assert.Equal(t, fileInfo{
+			permissions: 0o644,
+			content:     "this is file config\n",
+			userId:      0,
+			groupId:     0,
+		}, configContentThird, "Same config should be mountable to multiple paths, including nested directories")
 	})
 }

--- a/test/e2e/fixtures/compose-configs.yaml
+++ b/test/e2e/fixtures/compose-configs.yaml
@@ -11,6 +11,10 @@ services:
         uid: "1000"
         gid: "1000"
         mode: 0600
+      # Writing a config to a new, non-existent directory
+      - source: from-file
+        target: /etc/new-dir/config-from-file.conf
+        mode: 0644
     deploy:
       replicas: 1
 configs:

--- a/test/e2e/helpers.go
+++ b/test/e2e/helpers.go
@@ -71,7 +71,6 @@ func readFileInfoInContainer(t *testing.T, cli *client.Client, serviceNameOrID, 
 
 	// Parse permissions
 	permissions := strings.TrimSpace(permOutput)
-	fmt.Printf("Permissions output: %s\n", permissions)
 
 	// Parse three numbers: permissions, uid, gid
 	var permissionsOctal, uid, gid int


### PR DESCRIPTION
Fixes #232 and another issue that didn't allow to create two config mounts with the same source config.

It should more closely mirror now the Compose behavior which also uses the full target path in the tar header and extracts it to the root:

* https://github.com/docker/compose/blob/59f04b85af552dab7561255dcc08e9328c5bfe67/pkg/compose/secrets.go#L131
* https://github.com/docker/compose/blob/59f04b85af552dab7561255dcc08e9328c5bfe67/pkg/compose/secrets.go#L162