### PR TITLE
Add support for `cap_add` and `cap_drop` compose keys

### DIFF
--- a/internal/machine/docker/server.go
+++ b/internal/machine/docker/server.go
@@ -605,6 +605,8 @@ func (s *Server) CreateServiceContainer(
 		}
 	}
 	hostConfig := &container.HostConfig{
+		CapAdd:       spec.Container.CapAdd,
+		CapDrop:      spec.Container.CapDrop,
 		Binds:        spec.Container.Volumes,
 		Init:         spec.Container.Init,
 		Mounts:       mounts,

--- a/pkg/api/service.go
+++ b/pkg/api/service.go
@@ -225,6 +225,10 @@ func (s *ServiceSpec) Clone() ServiceSpec {
 // ContainerSpec defines the desired state of a container in a service.
 // ATTENTION: after changing this struct, verify if deploy.EvalContainerSpecChange needs to be updated.
 type ContainerSpec struct {
+	// Specifies which additional capabilities should be added for the container.
+	CapAdd []string
+	// Specifies which capabilities should be dropped from the container.
+	CapDrop []string
 	// Command overrides the default CMD of the image to be executed when running a container.
 	Command []string
 	// Entrypoint overrides the default ENTRYPOINT of the image.
@@ -342,6 +346,14 @@ func (s *ContainerSpec) Clone() ContainerSpec {
 		for i, cm := range s.ConfigMounts {
 			spec.ConfigMounts[i] = cm.Clone()
 		}
+	}
+	if s.CapAdd != nil {
+		spec.CapAdd = make([]string, len(s.CapAdd))
+		copy(spec.CapAdd, s.CapAdd)
+	}
+	if s.CapDrop != nil {
+		spec.CapDrop = make([]string, len(s.CapDrop))
+		copy(spec.CapDrop, s.CapDrop)
 	}
 
 	return spec

--- a/pkg/api/service_test.go
+++ b/pkg/api/service_test.go
@@ -209,6 +209,8 @@ func TestServiceSpec_Validate_CaddyAndPorts(t *testing.T) {
 func TestContainerSpec_Clone(t *testing.T) {
 	mode := os.FileMode(0o644)
 	original := ContainerSpec{
+		CapAdd:     []string{"NET_ADMIN"},
+		CapDrop:    []string{"ALL"},
 		Command:    []string{"sh", "-c", "echo hello"},
 		Entrypoint: []string{"/bin/bash"},
 		Env: EnvVars{
@@ -247,6 +249,8 @@ func TestContainerSpec_Clone(t *testing.T) {
 
 	// Verify deep copy by modifying the original
 	stringModified := "modified"
+	original.CapAdd[0] = stringModified
+	original.CapDrop[0] = stringModified
 	original.Command[0] = stringModified
 	original.Entrypoint[0] = stringModified
 	original.Env["FOO"] = stringModified
@@ -258,6 +262,8 @@ func TestContainerSpec_Clone(t *testing.T) {
 
 	assert.False(t, original.Equals(cloned))
 	// Assert cloned values are unchanged
+	assert.Equal(t, "NET_ADMIN", cloned.CapAdd[0])
+	assert.Equal(t, "ALL", cloned.CapDrop[0])
 	assert.Equal(t, "sh", cloned.Command[0])
 	assert.Equal(t, "/bin/bash", cloned.Entrypoint[0])
 	assert.Equal(t, "bar", cloned.Env["FOO"])

--- a/pkg/client/compose/service.go
+++ b/pkg/client/compose/service.go
@@ -43,6 +43,8 @@ func ServiceSpecFromCompose(project *types.Project, serviceName string) (api.Ser
 
 	spec := api.ServiceSpec{
 		Container: api.ContainerSpec{
+			CapAdd:     service.CapAdd,
+			CapDrop:    service.CapDrop,
 			Command:    service.Command,
 			Entrypoint: service.Entrypoint,
 			Env:        env,

--- a/pkg/client/compose/service_test.go
+++ b/pkg/client/compose/service_test.go
@@ -100,6 +100,8 @@ func TestServiceSpecFromCompose(t *testing.T) {
 					Name: "test",
 					Mode: api.ServiceModeReplicated,
 					Container: api.ContainerSpec{
+						CapAdd:     []string{"NET_ADMIN"},
+						CapDrop:    []string{"ALL"},
 						Command:    []string{"nginx", "updated", "command"},
 						Entrypoint: []string{"/updated-docker-entrypoint.sh"},
 						Env: map[string]string{

--- a/pkg/client/compose/testdata/compose-full-spec.yaml
+++ b/pkg/client/compose/testdata/compose-full-spec.yaml
@@ -1,5 +1,9 @@
 services:
   test:
+    cap_add:
+      - NET_ADMIN
+    cap_drop:
+      - ALL
     command: ["nginx", "updated", "command"]
     cpus: 0.5
     entrypoint: ["/updated-docker-entrypoint.sh"]

--- a/pkg/client/deploy/container_test.go
+++ b/pkg/client/deploy/container_test.go
@@ -9,6 +9,44 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestEvalContainerSpecChange_ContainerCapAdd(t *testing.T) {
+	t.Parallel()
+
+	currentSpec := api.ServiceSpec{
+		Container: api.ContainerSpec{
+			Image: "nginx:latest",
+		},
+	}
+	newSpec := api.ServiceSpec{
+		Container: api.ContainerSpec{
+			Image:  "nginx:latest",
+			CapAdd: []string{"NET_ADMIN"},
+		},
+	}
+
+	assert.Equal(t, ContainerNeedsRecreate, EvalContainerSpecChange(currentSpec, newSpec))
+	assert.Equal(t, ContainerNeedsRecreate, EvalContainerSpecChange(newSpec, currentSpec))
+}
+
+func TestEvalContainerSpecChange_ContainerCapDrop(t *testing.T) {
+	t.Parallel()
+
+	currentSpec := api.ServiceSpec{
+		Container: api.ContainerSpec{
+			Image: "nginx:latest",
+		},
+	}
+	newSpec := api.ServiceSpec{
+		Container: api.ContainerSpec{
+			Image:   "nginx:latest",
+			CapDrop: []string{"ALL"},
+		},
+	}
+
+	assert.Equal(t, ContainerNeedsRecreate, EvalContainerSpecChange(currentSpec, newSpec))
+	assert.Equal(t, ContainerNeedsRecreate, EvalContainerSpecChange(newSpec, currentSpec))
+}
+
 func TestEvalContainerSpecChange_ContainerResources(t *testing.T) {
 	t.Parallel()
 

--- a/website/docs/8-compose-file-reference/1-support-matrix.md
+++ b/website/docs/8-compose-file-reference/1-support-matrix.md
@@ -7,6 +7,8 @@ The following table shows the support status for main Compose features:
 |--------------------|--------------------|---------------------------------------------------------------------------------------|
 | **Services**       |                    |                                                                                       |
 | `build`            | ⚠️ Limited         | Build context and Dockerfile                                                          |
+| `cap_add`          | ✅ Supported        | Additional kernel capabilities                                                        |
+| `cap_drop`         | ✅ Supported        | Which capabilities to drop                                                            |
 | `command`          | ✅ Supported        | Override container command                                                            |
 | `configs`          | ✅ Supported        | File-based and inline configs                                                         |
 | `cpus`             | ✅ Supported        | CPU limit                                                                             |


### PR DESCRIPTION
There is already support for running containers in privileged mode, but no support for only giving/removing specific capabilities

Tested with my local cluster:

- Deploying an app without capabilities
- Redeploying the same app with added capabilities to check if container is recreated correctly

```
lynx@uncloud:~$ sudo docker inspect d4be13fe21cb | grep CapAdd -A 3
            "CapAdd": [
                "CAP_NET_ADMIN",
                "CAP_SYS_MODULE"
            ],
```