### PR TITLE
Add support for Rancher Desktop

### DIFF
--- a/pkg/client/image.go
+++ b/pkg/client/image.go
@@ -370,7 +370,7 @@ func isDockerVirtualised(ctx context.Context, dockerCli *docker.Client) (bool, e
 		return false, fmt.Errorf("get Docker info: %w", err)
 	}
 
-	virtualisedHostnames := []string{"docker-desktop", "colima"}
+	virtualisedHostnames := []string{"docker-desktop", "colima", "lima-rancher-desktop"}
 	for _, name := range virtualisedHostnames {
 		if strings.Contains(strings.ToLower(info.Name), name) {
 			return true, nil


### PR DESCRIPTION
Rancher Desktop is a free alternative to Docker Desktop (which prohibits commercial use) and has gained significant popularity. When running Rancher Desktop on non-native Docker platforms such as macOS and Windows, the secondary tunnel from the host OS to the Docker's Linux machine is necessary. At the moment, the check for this seems to be based on the vhost name of the docker engine's VM.

For Rancher Desktop it seemms to be `lima-rancher-desktop`:

```
$ docker info --format 'json' | jq .Name
"lima-rancher-desktop"
```

This might not be the best approach but is simple and should save a lot of headaches for a lot of people until a potentially better solution is devised.

See also: https://github.com/psviderski/unregistry/issues/62