### PR TITLE
feat: error on unsupported compose features

### DIFF
--- a/pkg/client/compose/project.go
+++ b/pkg/client/compose/project.go
@@ -13,6 +13,7 @@ import (
 	"github.com/compose-spec/compose-go/v2/tree"
 	"github.com/compose-spec/compose-go/v2/types"
 	"github.com/psviderski/uncloud/pkg/api"
+	"github.com/psviderski/uncloud/pkg/client"
 )
 
 var registerComposeOverrides sync.Once
@@ -67,7 +68,7 @@ func LoadProject(ctx context.Context, paths []string, opts ...composecli.Project
 	}
 
 	if err = validateServicesFeatures(project); err != nil {
-		return nil, err
+		client.PrintWarning(err.Error())
 	}
 
 	// Process image templates in services to expand Go template expressions using git repo state.

--- a/pkg/client/compose/project.go
+++ b/pkg/client/compose/project.go
@@ -66,6 +66,10 @@ func LoadProject(ctx context.Context, paths []string, opts ...composecli.Project
 		return nil, err
 	}
 
+	if err = validateServicesFeatures(project); err != nil {
+		return nil, err
+	}
+
 	// Process image templates in services to expand Go template expressions using git repo state.
 	if project, err = ProcessImageTemplates(project); err != nil {
 		return nil, err

--- a/pkg/client/compose/project_test.go
+++ b/pkg/client/compose/project_test.go
@@ -186,3 +186,69 @@ REDIS_URL=redis://localhost:6379
 		})
 	}
 }
+
+// TestLoadProject_Unsupported checks that unsupported features lead to an error.
+func TestLoadProject_Unsupported(t *testing.T) {
+	tests := []struct {
+		name        string
+		composeYAML string
+		verify      func(t *testing.T, projectDir string)
+	}{
+		{
+			name: "unsupported dns",
+			composeYAML: `services:
+  app:
+    image: myapp:latest
+    dns: 8.8.8.8
+`,
+			verify: func(t *testing.T, projectDir string) {
+				_, err := LoadProject(context.Background(), []string{filepath.Join(projectDir, "compose.yaml")})
+				require.Error(t, err)
+			},
+		},
+		{
+			name: "unsupported networks",
+			composeYAML: `services:
+  app:
+    image: myapp:latest
+    networks:
+      - frontend
+
+networks:
+  frontend:
+`,
+			verify: func(t *testing.T, projectDir string) {
+				_, err := LoadProject(context.Background(), []string{filepath.Join(projectDir, "compose.yaml")})
+				require.Error(t, err)
+			},
+		},
+		{
+			name: "supported networks",
+			composeYAML: `services:
+  app:
+    image: myapp:latest
+    networks:
+      - default
+
+networks:
+  default: {}
+`,
+			verify: func(t *testing.T, projectDir string) {
+				_, err := LoadProject(context.Background(), []string{filepath.Join(projectDir, "compose.yaml")})
+				require.NoError(t, err)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tempDir := t.TempDir()
+
+			composeFile := filepath.Join(tempDir, "compose.yaml")
+			err := os.WriteFile(composeFile, []byte(tt.composeYAML), 0o644)
+			require.NoError(t, err)
+
+			tt.verify(t, tempDir)
+		})
+	}
+}

--- a/pkg/client/compose/service.go
+++ b/pkg/client/compose/service.go
@@ -423,3 +423,52 @@ func validateServicesExtensions(project *types.Project) error {
 
 	return nil
 }
+
+// validateServicesFeatures checks the service for unsupported features and returns an error for this first one found.
+func validateServicesFeatures(project *types.Project) error {
+	err := func(service, feature string) error {
+		return fmt.Errorf("service: '%s': unsupported feature: '%s', see %s", service, feature, "https://uncloud.run/docs/compose-file-reference/support-matrix")
+	}
+
+	for _, service := range project.Services {
+		if service.SecurityOpt != nil {
+			return err(service.Name, "security_opt")
+		}
+		if service.DNS != nil {
+			return err(service.Name, "dns")
+		}
+		if service.DNSSearch != nil {
+			return err(service.Name, "dns_search")
+		}
+		if service.Labels != nil {
+			return err(service.Name, "labels")
+		}
+		if service.Links != nil {
+			return err(service.Name, "links")
+		}
+		if service.MemSwappiness > 0 {
+			return err(service.Name, "mem_swappiness")
+		}
+		if service.MemSwapLimit > 0 {
+			return err(service.Name, "memswap_limit")
+		}
+		if service.Secrets != nil {
+			return err(service.Name, "secrets")
+		}
+		if service.StorageOpt != nil {
+			return err(service.Name, "storage_opt")
+		}
+		// we only allow the 'default' network, nothing else.
+		if x := service.Networks; x != nil {
+			if len(x) != 1 {
+				return err(service.Name, "networks")
+			}
+			config, ok := x["default"]
+			if !ok || config != nil {
+				return err(service.Name, "networks")
+			}
+		}
+	}
+
+	return nil
+}


### PR DESCRIPTION
This implements a check for the unimplemented features of the uncloud support matrix and points to the matrix in the error.

Fixes: #237