### PR TITLE
feat: uc ls show status

### DIFF
--- a/cmd/uncloud/service/ls.go
+++ b/cmd/uncloud/service/ls.go
@@ -58,10 +58,11 @@ func list(ctx context.Context, uncli *cli.CLI) error {
 			return fmt.Errorf("write header: %w", err)
 		}
 	}
-	if _, err = fmt.Fprintln(tw, "NAME\tMODE\tREPLICAS\tIMAGE\tENDPOINTS"); err != nil {
+	if _, err = fmt.Fprintln(tw, "NAME\tMODE\tREPLICAS\tIMAGE\tENDPOINTS\tSTATUS"); err != nil {
 		return fmt.Errorf("write header: %w", err)
 	}
 	for _, s := range services {
+		statuses := strings.Join(s.Statuses(), ", ")
 		images := strings.Join(s.Images(), ", ")
 		endpoints := strings.Join(s.Endpoints(), ", ")
 
@@ -79,8 +80,8 @@ func list(ctx context.Context, uncli *cli.CLI) error {
 				return fmt.Errorf("write row: %w", err)
 			}
 		}
-		if _, err = fmt.Fprintf(tw, "%s\t%s\t%d\t%s\t%s\n",
-			s.Name, s.Mode, len(s.Containers), images, endpoints); err != nil {
+		if _, err = fmt.Fprintf(tw, "%s\t%s\t%d\t%s\t%s\t%s\n",
+			s.Name, s.Mode, len(s.Containers), images, endpoints, statuses); err != nil {
 			return fmt.Errorf("write row: %w", err)
 		}
 	}

--- a/pkg/api/service.go
+++ b/pkg/api/service.go
@@ -478,6 +478,14 @@ func (s *Service) MachineIDs() []string {
 	return ids.ToSlice()
 }
 
+func (s *Service) Statuses() []string {
+	statuses := make([]string, len(s.Containers))
+	for i, ctr := range s.Containers {
+		statuses[i] = ctr.Container.State.Status
+	}
+	return statuses
+}
+
 // Images returns a sorted list of unique images used by the service containers.
 func (s *Service) Images() []string {
 	images := make(map[string]struct{})


### PR DESCRIPTION
Plumb through the status of the containers.

```
NAME         MODE         REPLICAS   IMAGE                   ENDPOINTS   STATUS
excalidraw   replicated   1          excalidraw/excalidraw               running
```

Fixes: #13 
