### PR TITLE
Dockerfile: Get the correct corrosion version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,10 +39,11 @@ CMD ["corrosion", "agent"]
 
 FROM alpine:${ALPINE_VERSION} AS corrosion-image-tarball
 ARG CORROSION_IMAGE="ghcr.io/psviderski/corrosion:latest"
+ARG TARGETOS
+ARG TARGETARCH
 
 RUN apk --no-cache add crane
-RUN crane pull "${CORROSION_IMAGE}" /corrosion.tar
-
+RUN crane pull --platform ${TARGETOS}/${TARGETARCH} "${CORROSION_IMAGE}" /corrosion.tar
 
 # Uncloud-in-Docker (ucind) image for running Uncloud test clusters using Docker.
 FROM docker:27.3.1-dind AS ucind

--- a/HACKING.md
+++ b/HACKING.md
@@ -47,6 +47,16 @@ Windows:
 GOOS=linux GOARCH=amd64 go build -o uncloudd ./cmd/uncloudd
 ```
 
+## Docker in Docker (ucind)
+
+When running ucind and running in trouble, you must manually remove the cluster, by running:
+
+```shell
+docker stop CONTAINERID
+docker rm CONTAINERID
+docker network rm CLUSTERNAME
+```
+
 ## Testing
 
 Run all tests (unit and e2e):


### PR DESCRIPTION
On arm64 the x86 version of corrosion was downloaded. This downloads the correct version. Also added comments to HACKING.md on how to clean up a broken cluster as I have done it twice now and forgot how to do it both times.

Fixes: #284

~~~ shell
% ./ucind cluster create miektest
Cluster "miektest" initialised with machine "machine-1" Waiting for cluster to be ready... done.
Cluster 'miektest' added to Uncloud config as the current context. Cluster 'miektest' created.
~~~

`uc machine ls` also works.