### PR TITLE
✨ Quality: Loop variable pointer capture leads to identical API addresses

### DIFF
--- a/internal/ucind/config.go
+++ b/internal/ucind/config.go
@@ -28,9 +28,9 @@ func (u *ConfigUpdater) AddCluster(c Cluster) error {
 		Name:        c.Name,
 		Connections: make([]config.MachineConnection, len(c.Machines)),
 	}
-	for i, m := range c.Machines {
+	for i := range c.Machines {
 		clusterCfg.Connections[i] = config.MachineConnection{
-			TCP: &m.APIAddress,
+			TCP: &c.Machines[i].APIAddress,
 		}
 	}
 


### PR DESCRIPTION
## Problem

Taking the address of a loop variable field (`&m.APIAddress`) causes all `Connections[i].TCP` pointers to point to the same memory location. In Go versions prior to 1.22, the loop variable is reused across iterations, meaning all connections will end up with the API address of the last machine in the slice. Even in Go 1.22+, it is safer and more idiomatic to take the address of the slice element directly to avoid capturing a local copy's address.


**Severity**: `high`
**File**: `internal/ucind/config.go`

## Solution

Change the assignment to take the address of the slice element directly:


## Changes

- `internal/ucind/config.go` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced
