### PR TITLE
⚡ Performance: Unbuffered channel blocks Serf event loop

### DIFF
--- a/experiment/broadcaster.go
+++ b/experiment/broadcaster.go
@@ -23,7 +23,7 @@ func NewSerfBroadcaster(ctx context.Context, serf *serf.Serf) *SerfBroadcaster {
 	return &SerfBroadcaster{
 		ctx:    ctx,
 		serf:   serf,
-		nextCh: make(chan []byte),
+		nextCh: make(chan []byte, 16),
 	}
 }
 


### PR DESCRIPTION
## Problem

`nextCh` is an unbuffered channel. When `HandleEvent` receives a 'heads' event, it blocks on `b.nextCh <- userEvent.Payload` until the CRDT engine calls `Next()`. Because `HandleEvent` is typically called directly from Serf's event delivery loop, this synchronous handoff will block all Serf event processing (including node joins, leaves, and gossip) whenever the CRDT engine is busy and not actively waiting to read the next event.

**Severity**: `high`
**File**: `experiment/broadcaster.go`

## Solution

Initialize `nextCh` with a reasonable buffer to decouple the Serf event loop from the CRDT processing loop.


## Changes

- `experiment/broadcaster.go` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced
