### PR TITLE
✨ Quality: Update Corrosion version to v0.2.3

### DIFF
--- a/internal/machine/constants.go
+++ b/internal/machine/constants.go
@@ -1,0 +1,9 @@
+package machine
+
+const (
+	// DefaultDataDir is the default directory for storing persistent machine state.
+	DefaultDataDir = "/var/lib/uncloud"
+
+	// CorrosionVersion is the version of Corrosion to use.
+	CorrosionVersion = "v0.2.3"
+)


### PR DESCRIPTION
## Problem

Update the Corrosion version to v0.2.3 to use the binary built with an older GLIBC (ubuntu-20.04), which adds support for Amazon Linux 2023 (GLIBC 2.34).

**Severity**: `high`
**File**: `internal/machine/constants.go`

## Solution

Locate the constant defining the Corrosion version (e.g., `CorrosionVersion = "v0.2.2"`) and update its value to `"v0.2.3"`.

## Changes

- `internal/machine/constants.go` (new)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced


Closes #227