### PR TITLE
feat: check autom if we can connect via Unix socket

### DIFF
--- a/cmd/uncloud/machine/init.go
+++ b/cmd/uncloud/machine/init.go
@@ -150,11 +150,13 @@ Connection methods:
 
 func initCluster(ctx context.Context, uncli *cli.CLI, remoteMachine *cli.RemoteMachine, opts initOptions) error {
 	if uncli.Config == nil {
-		// Config is nil when connecting directly to a remote machine (--connect) without using Uncloud config.
+		// Config is nil when connecting directly to a remote machine (--connect) without using Uncloud config
+		// or when being logged in on a machine and using the uncloud socket directly.
 		return fmt.Errorf(
 			"do not use --connect when initialising a new cluster: --connect is for overriding the connection " +
 				"to an existing cluster, but 'machine init' creates a new one and writes the new cluster context " +
-				"to the Uncloud config file (--uncloud-config)")
+				"to the Uncloud config file (--uncloud-config), when logged in on a cluster machine, 'machine init' " +
+				"is not supported")
 	}
 
 	netPrefix, err := netip.ParsePrefix(opts.network)

--- a/cmd/uncloud/main.go
+++ b/cmd/uncloud/main.go
@@ -11,7 +11,7 @@ import (
 	cmdcontext "github.com/psviderski/uncloud/cmd/uncloud/context"
 	"github.com/psviderski/uncloud/cmd/uncloud/dns"
 	"github.com/psviderski/uncloud/cmd/uncloud/image"
-	"github.com/psviderski/uncloud/cmd/uncloud/machine"
+	cmdmachine "github.com/psviderski/uncloud/cmd/uncloud/machine"
 	"github.com/psviderski/uncloud/cmd/uncloud/service"
 	"github.com/psviderski/uncloud/cmd/uncloud/volume"
 	"github.com/psviderski/uncloud/cmd/uncloud/wg"
@@ -19,6 +19,7 @@ import (
 	"github.com/psviderski/uncloud/internal/cli/config"
 	"github.com/psviderski/uncloud/internal/fs"
 	"github.com/psviderski/uncloud/internal/log"
+	"github.com/psviderski/uncloud/internal/machine"
 	"github.com/psviderski/uncloud/internal/version"
 	"github.com/spf13/cobra"
 )
@@ -46,24 +47,22 @@ func main() {
 
 			var conn *config.MachineConnection
 			if opts.connect != "" {
-				if strings.HasPrefix(opts.connect, "tcp://") {
-					addrPort, err := netip.ParseAddrPort(strings.TrimPrefix(opts.connect, "tcp://"))
+				if after, ok := strings.CutPrefix(opts.connect, "tcp://"); ok {
+					addrPort, err := netip.ParseAddrPort(after)
 					if err != nil {
 						return fmt.Errorf("parse TCP address: %w", err)
 					}
 					conn = &config.MachineConnection{
 						TCP: &addrPort,
 					}
-				} else if strings.HasPrefix(opts.connect, "ssh+go://") {
-					dest := strings.TrimPrefix(opts.connect, "ssh+go://")
+				} else if after, ok := strings.CutPrefix(opts.connect, "ssh+go://"); ok {
 					conn = &config.MachineConnection{
-						SSHGo: config.SSHDestination(dest),
+						SSHGo: config.SSHDestination(after),
 					}
-				} else if strings.HasPrefix(opts.connect, "ssh+cli://") {
+				} else if after, ok := strings.CutPrefix(opts.connect, "ssh+cli://"); ok {
 					// Backward-compatible alias for ssh://.
-					dest := strings.TrimPrefix(opts.connect, "ssh+cli://")
 					conn = &config.MachineConnection{
-						SSH: config.SSHDestination(dest),
+						SSH: config.SSHDestination(after),
 					}
 				} else if strings.HasPrefix(opts.connect, "unix://") {
 					conn = &config.MachineConnection{
@@ -79,6 +78,15 @@ func main() {
 			}
 
 			configPath := fs.ExpandHomeDir(opts.configPath)
+
+			if opts.connect == "" {
+				if !fs.Exists(configPath) && fs.Exists(machine.DefaultUncloudSockPath) {
+					conn = &config.MachineConnection{
+						Unix: machine.DefaultUncloudSockPath,
+					}
+				}
+			}
+
 			uncli, err := cli.New(configPath, conn, opts.context)
 			if err != nil {
 				return fmt.Errorf("initialise CLI: %w", err)
@@ -130,7 +138,7 @@ func main() {
 		cmdcontext.NewRootCommand(),
 		dns.NewRootCommand(),
 		image.NewRootCommand(),
-		machine.NewRootCommand(),
+		cmdmachine.NewRootCommand(),
 		service.NewRootCommand(),
 		service.NewExecCommand("service"),
 		service.NewInspectCommand("service"),

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -54,10 +54,6 @@ func New(configPath string, conn *config.MachineConnection, contextName string) 
 }
 
 func (cli *CLI) CreateContext(name string) error {
-	if cli.conn.Unix != "" {
-		return fmt.Errorf("local unix socket connection '%s', not creating Uncloud config", cli.conn.Unix)
-	}
-
 	if _, ok := cli.Config.Contexts[name]; ok {
 		return fmt.Errorf("context '%s' already exists", name)
 	}

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -54,6 +54,10 @@ func New(configPath string, conn *config.MachineConnection, contextName string) 
 }
 
 func (cli *CLI) CreateContext(name string) error {
+	if cli.conn.Unix != "" {
+		return fmt.Errorf("local unix socket connection '%s', not creating Uncloud config", cli.conn.Unix)
+	}
+
 	if _, ok := cli.Config.Contexts[name]; ok {
 		return fmt.Errorf("context '%s' already exists", name)
 	}

--- a/internal/fs/fs.go
+++ b/internal/fs/fs.go
@@ -71,3 +71,8 @@ func Chown(path, username, group string) error {
 	}
 	return nil
 }
+
+func Exists(path string) bool {
+	_, err := os.Stat(path)
+	return err == nil
+}


### PR DESCRIPTION
When there is no config, but a unix socket does exist, connect via the unix socket. Prohibit saving the config if this is the case.

Fixes: #148

Use the new CutPrefix to shorten some code.