### PR TITLE
feat: Add x-registry to compose files for private docker registries

### DIFF
--- a/internal/machine/docker/server.go
+++ b/internal/machine/docker/server.go
@@ -21,8 +21,6 @@ import (
 
 	"github.com/containerd/errdefs"
 	"github.com/distribution/reference"
-	dockercommand "github.com/docker/cli/cli/command"
-	dockerconfig "github.com/docker/cli/cli/config"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/filters"
@@ -276,14 +274,6 @@ func (s *Server) PullImage(req *pb.PullImageRequest, stream grpc.ServerStreaming
 	if len(req.Options) > 0 {
 		if err := json.Unmarshal(req.Options, &opts); err != nil {
 			return status.Errorf(codes.InvalidArgument, "unmarshal options: %v", err)
-		}
-	}
-
-	if opts.RegistryAuth == "" {
-		// Try to retrieve the authentication token for the image from the default local Docker config file.
-		dockerConfig := dockerconfig.LoadDefaultConfigFile(os.Stderr)
-		if encodedAuth, err := dockercommand.RetrieveAuthTokenFromImage(dockerConfig, req.Image); err == nil {
-			opts.RegistryAuth = encodedAuth
 		}
 	}
 

--- a/pkg/api/service.go
+++ b/pkg/api/service.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"maps"
@@ -11,6 +12,7 @@ import (
 
 	mapset "github.com/deckarep/golang-set/v2"
 	"github.com/distribution/reference"
+	"github.com/docker/docker/api/types/registry"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/psviderski/uncloud/internal/machine/api/pb"
@@ -59,6 +61,8 @@ type ServiceSpec struct {
 	Configs []ConfigSpec
 	// Container defines the desired state of each container in the service.
 	Container ContainerSpec
+	// Registry defines credentials for connecting to (private) registries.
+	Registry RegistrySpec
 	// Mode is the replication mode of the service. Default is ServiceModeReplicated if empty.
 	Mode string
 	Name string
@@ -611,4 +615,34 @@ func machineContainerFromProto(sc *pb.Service_Container) (MachineServiceContaine
 		MachineID: sc.MachineId,
 		Container: ServiceContainer{Container: c},
 	}, nil
+}
+
+// Credential holds the actual credentials.
+type Credential struct {
+	Username string
+	Password string
+}
+
+// registryAuth returns the credentials as a base64 encoded string for use in the docker PullOptions.
+func (c Credential) registryAuth() string {
+	authConfig := registry.AuthConfig{
+		Username: c.Username,
+		Password: c.Password,
+	}
+	encodedJSON, _ := json.Marshal(authConfig)
+	return base64.URLEncoding.EncodeToString(encodedJSON)
+}
+
+// RegistrySpec holds the credentials to connect to private registries.
+type RegistrySpec map[string]Credential
+
+// RegistryAuth checks the credentials in r and returns the authentication if an image uses a private
+// registry.
+func (r RegistrySpec) RegistryAuth(image string) string {
+	for registry, c := range r {
+		if strings.HasPrefix(image, registry) {
+			return c.registryAuth()
+		}
+	}
+	return ""
 }

--- a/pkg/client/compose/project.go
+++ b/pkg/client/compose/project.go
@@ -40,6 +40,7 @@ func LoadProject(ctx context.Context, paths []string, opts ...composecli.Project
 		composecli.WithExtension(MachinesExtensionKey, MachinesSource{}),
 		composecli.WithExtension(PortsExtensionKey, PortsSource{}),
 		composecli.WithExtension(PreDeployHookExtensionKey, PreDeployHook{}),
+		composecli.WithExtension(RegistryExtensionKey, RegistrySource{}),
 	}
 
 	options, err := composecli.NewProjectOptions(

--- a/pkg/client/compose/registry.go
+++ b/pkg/client/compose/registry.go
@@ -1,0 +1,8 @@
+package compose
+
+const RegistryExtensionKey = "x-registry"
+
+type RegistrySource map[string]struct {
+	Username string
+	Password string
+}

--- a/pkg/client/compose/service.go
+++ b/pkg/client/compose/service.go
@@ -77,6 +77,15 @@ func ServiceSpecFromCompose(project *types.Project, serviceName string) (api.Ser
 	if machines, ok := service.Extensions[MachinesExtensionKey].(MachinesSource); ok {
 		spec.Placement.Machines = machines
 	}
+	if registry, ok := service.Extensions[RegistryExtensionKey].(RegistrySource); ok {
+		spec.Registry = make(api.RegistrySpec, len(registry))
+		for r, cred := range registry {
+			spec.Registry[r] = api.Credential{
+				Username: cred.Username,
+				Password: cred.Password,
+			}
+		}
+	}
 
 	// Map LogDriver if specified
 	if service.Logging != nil && service.Logging.Driver != "" {

--- a/pkg/client/compose/service_test.go
+++ b/pkg/client/compose/service_test.go
@@ -205,6 +205,9 @@ func TestServiceSpecFromCompose(t *testing.T) {
 							Mode:          api.PortModeHost,
 						},
 					},
+					Registry: api.RegistrySpec{
+						"registry.science.ru.nl": {Username: "example", Password: "pass"},
+					},
 					Placement: api.Placement{
 						Machines: []string{"machine-1", "machine-2"},
 					},

--- a/pkg/client/compose/testdata/compose-full-spec.yaml
+++ b/pkg/client/compose/testdata/compose-full-spec.yaml
@@ -85,6 +85,10 @@ services:
       privileged: false
       timeout: 2m30s
       user: root
+    x-registry:
+      registry.science.ru.nl:
+        username: example
+        password: pass
 
   test-caddy-config:
     image: myapp:1.2.3

--- a/pkg/client/container.go
+++ b/pkg/client/container.go
@@ -12,7 +12,6 @@ import (
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/pkg/jsonmessage"
 	cliprogress "github.com/psviderski/uncloud/internal/cli/progress"
-	"github.com/psviderski/uncloud/internal/docker"
 	"github.com/psviderski/uncloud/internal/machine/api/pb"
 	machinedocker "github.com/psviderski/uncloud/internal/machine/docker"
 	"github.com/psviderski/uncloud/internal/secret"
@@ -81,7 +80,7 @@ func (cli *Client) createServiceContainerWithPull(
 	pw.Event(progress.CreatingEvent(eventID))
 
 	if spec.Container.PullPolicy == api.PullPolicyAlways {
-		if err = cli.pullImageWithProgress(ctx, spec.Container.Image, machine.Machine.Name, eventID); err != nil {
+		if err = cli.pullImageWithProgress(ctx, spec.Container.Image, machine.Machine.Name, eventID, spec.Registry); err != nil {
 			return resp, err
 		}
 	}
@@ -113,7 +112,7 @@ func (cli *Client) createServiceContainerWithPull(
 		}
 
 		// Pull the missing image and create the container again.
-		if err = cli.pullImageWithProgress(ctx, spec.Container.Image, machine.Machine.Name, eventID); err != nil {
+		if err = cli.pullImageWithProgress(ctx, spec.Container.Image, machine.Machine.Name, eventID, spec.Registry); err != nil {
 			return resp, err
 		}
 		if grpcResp, err = cli.Docker.GRPCClient.CreateServiceContainer(ctx, req); err != nil {
@@ -129,7 +128,7 @@ func (cli *Client) createServiceContainerWithPull(
 	return resp, nil
 }
 
-func (cli *Client) pullImageWithProgress(ctx context.Context, image, machineName, parentEventID string) error {
+func (cli *Client) pullImageWithProgress(ctx context.Context, image, machineName, parentEventID string, regspec api.RegistrySpec) error {
 	pw := progress.ContextWriter(ctx)
 	eventID := cliprogress.ImageEventID(image, machineName)
 	pw.Event(progress.Event{
@@ -140,10 +139,8 @@ func (cli *Client) pullImageWithProgress(ctx context.Context, image, machineName
 	})
 
 	opts := machinedocker.PullOptions{}
-	// Try to retrieve the authentication token for the image from the default local Docker config file.
-	if encodedAuth, err := docker.RetrieveLocalDockerRegistryAuth(image); err == nil {
-		// If RegistryAuth is empty, Uncloud daemon will try to retrieve the credentials from its own Docker config.
-		opts.RegistryAuth = encodedAuth
+	if auth := regspec.RegistryAuth(image); auth != "" {
+		opts.RegistryAuth = auth
 	}
 
 	pullCh, err := cli.Docker.PullImage(ctx, image, opts)

--- a/website/docs/8-compose-file-reference/1-support-matrix.md
+++ b/website/docs/8-compose-file-reference/1-support-matrix.md
@@ -10,16 +10,16 @@ If you rely on a specific Compose feature that is not supported by Uncloud, plea
 
 :::
 
-| Feature                          | Support Status     | Notes                                                                                                          |
-|----------------------------------|--------------------|----------------------------------------------------------------------------------------------------------------|
-| **Services**                     |                    |                                                                                                                |
+| Feature                          | Support Status      | Notes                                                                                                          |
+| -------------------------------- | ------------------- | -------------------------------------------------------------------------------------------------------------- |
+| **Services**                     |                     |                                                                                                                |
 | `build`                          | ✅ Supported        | Build context and Dockerfile                                                                                   |
 | `cap_add`                        | ✅ Supported        | Additional kernel [capabilities](https://man7.org/linux/man-pages/man7/capabilities.7.html)                    |
 | `cap_drop`                       | ✅ Supported        | Which kernel [capabilities](https://man7.org/linux/man-pages/man7/capabilities.7.html) to drop                 |
 | `command`                        | ✅ Supported        | Override container command                                                                                     |
 | `configs`                        | ✅ Supported        | File-based and inline configs                                                                                  |
 | `cpus`                           | ✅ Supported        | CPU limit                                                                                                      |
-| `depends_on`                     | ⚠️ Limited         | Services deployed in order but conditions not checked                                                          |
+| `depends_on`                     | ⚠️ Limited          | Services deployed in order but conditions not checked                                                          |
 | `devices`                        | ✅ Supported        | Device mappings                                                                                                |
 | `dns`                            | ❌ Not supported    | Built-in service discovery                                                                                     |
 | `dns_search`                     | ❌ Not supported    | Built-in service discovery                                                                                     |
@@ -39,7 +39,7 @@ If you rely on a specific Compose feature that is not supported by Uncloud, plea
 | `memswap_limit`                  | ❌ Not supported    |                                                                                                                |
 | `networks`                       | ❌ Not supported    | All containers share cluster network                                                                           |
 | `pid`                            | ✅ Supported        | Set the PID namespace mode, `pid: host` only                                                                   |
-| `ports`                          | ⚠️ Limited         | `mode: host` only, use [`x-ports`](#x-ports) for HTTP/HTTPS                                                    |
+| `ports`                          | ⚠️ Limited          | `mode: host` only, use [`x-ports`](#x-ports) for HTTP/HTTPS                                                    |
 | `privileged`                     | ✅ Supported        | Run containers in privileged mode                                                                              |
 | `pull_policy`                    | ✅ Supported        | `always`, `missing`, `never`                                                                                   |
 | `secrets`                        | ❌ Not supported    | Use configs or environment variables                                                                           |
@@ -51,37 +51,35 @@ If you rely on a specific Compose feature that is not supported by Uncloud, plea
 | `ulimits`                        | ✅ Supported        | Resource limits                                                                                                |
 | `user`                           | ✅ Supported        | Set container user                                                                                             |
 | `volumes`                        | ✅ Supported        | Named volumes, bind mounts, tmpfs                                                                              |
-| **Deploy**                       |                    |                                                                                                                |
+| **Deploy**                       |                     |                                                                                                                |
 | `labels`                         | ❌ Not supported    |                                                                                                                |
 | `mode`                           | ✅ Supported        | Either `global` or `replicated`                                                                                |
 | `placement`                      | ❌ Not supported    | Use [`x-machines`](#x-machines) extension                                                                      |
 | `replicas`                       | ✅ Supported        | Number of container replicas                                                                                   |
-| `resources`                      | ⚠️ Limited         | CPU, memory limits and device reservations                                                                     |
+| `resources`                      | ⚠️ Limited          | CPU, memory limits and device reservations                                                                     |
 | `restart_policy`                 | ❌ Not supported    | Defaults to `unless-stopped`                                                                                   |
 | `rollback_config`                | ❌ Not supported    | See [#151](https://github.com/psviderski/uncloud/issues/151)                                                   |
-| `update_config`                  | ⚠️ Limited         | `order` and `monitor` supported. See [rolling deployments](../4-guides/1-deployments/4-rolling-deployments.md) |
-| **Volumes**                      |                    |                                                                                                                |
+| `update_config`                  | ⚠️ Limited          | `order` and `monitor` supported. See [rolling deployments](../4-guides/1-deployments/4-rolling-deployments.md) |
+| **Volumes**                      |                     |                                                                                                                |
 | Named volumes                    | ✅ Supported        | Docker volumes                                                                                                 |
 | Bind mounts                      | ✅ Supported        | Host path binding                                                                                              |
 | Tmpfs mounts                     | ✅ Supported        | In-memory filesystems                                                                                          |
 | Volume labels                    | ✅ Supported        | Custom labels                                                                                                  |
 | External volumes                 | ✅ Supported        | Must exist before deployment                                                                                   |
 | [Volume drivers][volume-drivers] | ✅ Supported        | `local` (supports [NFS][volume-nfs], [CIFS/Samba][volume-cifs]) and manually installed third-party drivers     |
-| **Configs**                      |                    |                                                                                                                |
+| **Configs**                      |                     |                                                                                                                |
 | File-based configs               | ✅ Supported        | Read from file                                                                                                 |
 | Inline configs                   | ✅ Supported        | Defined in compose file                                                                                        |
 | External configs                 | ❌ Not supported    | Not supported                                                                                                  |
 | Short syntax                     | ❌ Not supported    | Use long syntax only                                                                                           |
-| **Extensions**                   |                    |                                                                                                                |
+| **Extensions**                   |                     |                                                                                                                |
 | `x-context`                      | ✅ Uncloud-specific | Cluster context override                                                                                       |
 | `x-caddy`                        | ✅ Uncloud-specific | Custom Caddy configuration                                                                                     |
 | `x-machines`                     | ✅ Uncloud-specific | Machine placement constraints                                                                                  |
 | `x-ports`                        | ✅ Uncloud-specific | Service port publishing                                                                                        |
 
 [volume-drivers]: https://docs.docker.com/engine/storage/volumes/#use-a-volume-driver
-
 [volume-nfs]: https://docs.docker.com/engine/storage/volumes/#create-a-service-which-creates-an-nfs-volume
-
 [volume-cifs]: https://docs.docker.com/engine/storage/volumes/#create-cifssamba-volumes
 
 ### Legend
@@ -166,4 +164,18 @@ services:
       - machine-2
     # Short syntax for a single machine
     # x-machines: machine-1
+```
+
+### `x-registry`
+
+This allows for setting credentails for private Docker registries, and can hold multiple registries.
+
+```yaml
+services:
+  web:
+    image: myregistry.example.com/private/nginx
+    x-registry:
+      myregistry.example.com:
+        username: xxxxx
+        password: yyyyy
 ```


### PR DESCRIPTION
This allows setting credentials for private docker registries. The syntax is copied from Rancher.

Documentation is updated, there is no unit test, it was tested manually and works with the local private registry (GitLab).

Functionality for retrieving the auth tokens locally is removed, also because I had a hard time getting this to work, and seems awkward to a log into a remote machine to do a 'docker login'.

Fixes: #299