### PR TITLE
feat: uc ctx ls add --short option

### DIFF
--- a/cmd/uncloud/context/ls.go
+++ b/cmd/uncloud/context/ls.go
@@ -10,32 +10,52 @@ import (
 	"github.com/spf13/cobra"
 )
 
+type listOptions struct {
+	short bool
+}
+
 func NewListCommand() *cobra.Command {
+	opts := listOptions{}
 	cmd := &cobra.Command{
 		Use:     "ls",
 		Aliases: []string{"list"},
 		Short:   "List available cluster contexts.",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			uncli := cmd.Context().Value("cli").(*cli.CLI)
-			return list(uncli)
+			return list(uncli, opts)
 		},
 	}
+
+	cmd.Flags().BoolVar(&opts.short, "short", false,
+		"Show the current cluster context only.")
 
 	return cmd
 }
 
-func list(uncli *cli.CLI) error {
+func list(uncli *cli.CLI, opts listOptions) error {
 	if uncli.Config == nil {
 		return fmt.Errorf("context management is not available: Uncloud configuration file is not being used")
 	}
 
 	if len(uncli.Config.Contexts) == 0 {
-		fmt.Println("No contexts found")
+		if !opts.short {
+			fmt.Println("No contexts found")
+		}
 		return nil
 	}
 
 	contextNames := slices.Sorted(maps.Keys(uncli.Config.Contexts))
 	currentContext := uncli.Config.CurrentContext
+
+	if opts.short {
+		for _, name := range contextNames {
+			if name == currentContext {
+				fmt.Println(name)
+				break
+			}
+		}
+		return nil
+	}
 
 	t := tui.NewTable()
 	t.Headers("NAME", "CURRENT", "CONNECTIONS")

--- a/website/docs/9-cli-reference/uc_ctx_ls.md
+++ b/website/docs/9-cli-reference/uc_ctx_ls.md
@@ -9,7 +9,8 @@ uc ctx ls [flags]
 ## Options
 
 ```
-  -h, --help   help for ls
+  -h, --help    help for ls
+      --short   Show the current cluster context only.
 ```
 
 ## Options inherited from parent commands


### PR DESCRIPTION
This just prints the default context and nothing on error. This allows the use of `uc ctx ls --short` in your shell prompt to print the current context however you like. Is also saves on execs, as you don't need a little pipeline to filter stuff.

See: #311