### PR TITLE
feat: ucind: implement cluster list

### DIFF
--- a/cmd/ucind/cluster/ls.go
+++ b/cmd/ucind/cluster/ls.go
@@ -1,0 +1,40 @@
+package cluster
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/psviderski/uncloud/internal/cli/tui"
+	"github.com/psviderski/uncloud/internal/ucind"
+	"github.com/spf13/cobra"
+)
+
+func NewListCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "ls",
+		Aliases: []string{"list"},
+		Short:   "List clusters.",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			p := cmd.Context().Value("provisioner").(*ucind.Provisioner)
+			clusters, err := p.ListClusters(cmd.Context())
+			if err != nil {
+				return fmt.Errorf("list clusters: %w", err)
+			}
+			t := tui.NewTable()
+			t.Headers("NAME", "MACHINES")
+			for _, cluster := range clusters {
+				machines := []string{}
+				for _, m := range cluster.Machines {
+					machines = append(machines, m.Name)
+				}
+				t.Row(
+					cluster.Name,
+					strings.Join(machines, tui.Faint.Render(", ")),
+				)
+			}
+			fmt.Println(t)
+			return nil
+		},
+	}
+	return cmd
+}

--- a/cmd/ucind/cluster/root.go
+++ b/cmd/ucind/cluster/root.go
@@ -13,7 +13,7 @@ func NewRootCommand() *cobra.Command {
 	}
 	cmd.AddCommand(
 		NewCreateCommand(),
-		// NewListCommand(),
+		NewListCommand(),
 		NewRemoveCommand(),
 	)
 	return cmd

--- a/internal/ucind/cluster.go
+++ b/internal/ucind/cluster.go
@@ -323,7 +323,11 @@ func (p *Provisioner) WaitClusterReady(ctx context.Context, c Cluster, timeout t
 }
 
 func (p *Provisioner) ListClusters(ctx context.Context) ([]Cluster, error) {
-	nets, err := p.dockerCli.NetworkList(ctx, network.ListOptions{})
+	nets, err := p.dockerCli.NetworkList(ctx, network.ListOptions{
+		Filters: filters.NewArgs(
+			filters.Arg("label", ManagedLabel),
+		),
+	})
 	if err != nil {
 		return nil, err
 	}

--- a/internal/ucind/cluster.go
+++ b/internal/ucind/cluster.go
@@ -322,6 +322,22 @@ func (p *Provisioner) WaitClusterReady(ctx context.Context, c Cluster, timeout t
 	return nil
 }
 
+func (p *Provisioner) ListClusters(ctx context.Context) ([]Cluster, error) {
+	nets, err := p.dockerCli.NetworkList(ctx, network.ListOptions{})
+	if err != nil {
+		return nil, err
+	}
+
+	clusters := []Cluster{}
+	for _, net := range nets {
+		cluster, err := p.InspectCluster(ctx, net.Name)
+		if err == nil {
+			clusters = append(clusters, cluster)
+		}
+	}
+	return clusters, nil
+}
+
 func (p *Provisioner) RemoveCluster(ctx context.Context, name string) error {
 	if _, err := p.InspectCluster(ctx, name); err != nil {
 		if errors.Is(err, ErrNotFound) {


### PR DESCRIPTION
I keep forgetting my ucind clusters, that add the missing list command:
```
% ./ucind cluster list
NAME    MACHINES
miek1   machine-1
```

Just the name would have been enough, but to actually make use of the tui table a machines list is handy as well.
(There isn't much bubbletea in ucind, but I thought lets start now).