### PR TITLE
feat: add uc ctx show

### DIFF
--- a/cmd/uncloud/context/root.go
+++ b/cmd/uncloud/context/root.go
@@ -20,6 +20,7 @@ func NewRootCommand() *cobra.Command {
 		NewListCommand(),
 		NewUseCommand(),
 		NewConnectionCommand(),
+		NewShowCommand(),
 	)
 
 	return cmd

--- a/cmd/uncloud/context/show.go
+++ b/cmd/uncloud/context/show.go
@@ -1,0 +1,35 @@
+package context
+
+import (
+	"fmt"
+
+	"github.com/psviderski/uncloud/internal/cli"
+	"github.com/spf13/cobra"
+)
+
+func NewShowCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "show",
+		Short: "Show current cluster context.",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			uncli := cmd.Context().Value("cli").(*cli.CLI)
+			return show(uncli)
+		},
+	}
+
+	return cmd
+}
+
+func show(uncli *cli.CLI) error {
+	// discard errors, only show the current context, otherwise nothing
+	if uncli.Config == nil {
+		return nil
+	}
+
+	if len(uncli.Config.Contexts) == 0 {
+		return nil
+	}
+	fmt.Println(uncli.Config.CurrentContext)
+
+	return nil
+}

--- a/website/docs/9-cli-reference/uc_ctx.md
+++ b/website/docs/9-cli-reference/uc_ctx.md
@@ -26,5 +26,6 @@ uc ctx [flags]
 * [uc](uc.md)	 - A CLI tool for managing Uncloud resources such as machines, services, and volumes.
 * [uc ctx connection](uc_ctx_connection.md)	 - Choose a new default connection for the current context.
 * [uc ctx ls](uc_ctx_ls.md)	 - List available cluster contexts.
+* [uc ctx show](uc_ctx_show.md)	 - Show current cluster context.
 * [uc ctx use](uc_ctx_use.md)	 - Switch to a different cluster context.
 


### PR DESCRIPTION
This only shows the current context and nothing more. On error nothing is printed (also no error). This is useful to include in your prompt.

See: #314