### PR TITLE
feat: allow binding to an interface

### DIFF
--- a/cmd/uncloud/service/run.go
+++ b/cmd/uncloud/service/run.go
@@ -100,7 +100,8 @@ func NewRunCommand(groupID string) *cobra.Command {
 			"  -p app.example.com:8080/https  Publish port 8080 as HTTPS via reverse proxy with custom hostname\n"+
 			// TODO: add support for publishing L4 tcp/udp ports.
 			//"  -p 9000:8080                   Publish port 8080 as TCP port 9000 via reverse proxy\n"+
-			"  -p 53:5353/udp@host            Bind UDP port 5353 to host port 53")
+			"  -p 53:5353/udp@host            Bind UDP port 5353 to host port 53"+
+			"  -p enp1s0:54:5443@host         Bind TCP port 5453 to host port 54 on interface enp1s0")
 	cmd.Flags().StringVar(&opts.pull, "pull", api.PullPolicyMissing,
 		fmt.Sprintf("Pull image from the registry before running service containers ('%s', '%s', '%s').",
 			api.PullPolicyAlways, api.PullPolicyMissing, api.PullPolicyNever))

--- a/cmd/uncloud/service/run.go
+++ b/cmd/uncloud/service/run.go
@@ -101,7 +101,7 @@ func NewRunCommand(groupID string) *cobra.Command {
 			// TODO: add support for publishing L4 tcp/udp ports.
 			//"  -p 9000:8080                   Publish port 8080 as TCP port 9000 via reverse proxy\n"+
 			"  -p 53:5353/udp@host            Bind UDP port 5353 to host port 53"+
-			"  -p enp1s0:54:5443@host         Bind TCP port 5453 to host port 54 on interface enp1s0")
+			"  -p enp1s0:54:5454@host         Bind TCP port 5454 to host port 54 on interface enp1s0")
 	cmd.Flags().StringVar(&opts.pull, "pull", api.PullPolicyMissing,
 		fmt.Sprintf("Pull image from the registry before running service containers ('%s', '%s', '%s').",
 			api.PullPolicyAlways, api.PullPolicyMissing, api.PullPolicyNever))

--- a/internal/machine/docker/interface.go
+++ b/internal/machine/docker/interface.go
@@ -1,0 +1,43 @@
+package docker
+
+import (
+	"fmt"
+	"net"
+)
+
+func addrsFromInterface(iface net.Interface) ([]string, error) {
+	ifis, err := net.Interfaces()
+	if err != nil {
+		return nil, err
+	}
+	var addrs []net.Addr
+	ok := false
+	for _, ifi := range ifis {
+		if ifi.Name == iface.Name {
+			ok = true
+			addrs, _ = ifi.Addrs()
+		}
+	}
+	if !ok {
+		return nil, fmt.Errorf("interface name '%s' not found", iface.Name)
+	}
+	if len(addrs) == 0 {
+		return nil, fmt.Errorf("interface '%s' has no addresses", iface.Name)
+	}
+
+	ips := []string{}
+	for _, addr := range addrs {
+		ipnet, ok := addr.(*net.IPNet)
+		if !ok {
+			continue
+		}
+		if ipnet.IP.IsLoopback() || ipnet.IP.IsPrivate() {
+			continue
+		}
+		if ipnet.IP.IsLinkLocalUnicast() || ipnet.IP.IsUnspecified() {
+			continue
+		}
+		ips = append(ips, ipnet.IP.String())
+	}
+	return ips, nil
+}

--- a/internal/machine/docker/server.go
+++ b/internal/machine/docker/server.go
@@ -620,6 +620,21 @@ func (s *Server) CreateServiceContainer(
 		if p.HostIP.IsValid() {
 			portBindings[port][0].HostIP = p.HostIP.String()
 		}
+		if p.Interface.Name != "" {
+			addrs, err := addrsFromInterface(p.Interface)
+			if err != nil {
+				return nil, err
+			}
+			// p.HostIP must not valid, so the first IP can be set in the above added PortBinding, the rest is
+			// then just appended.
+			portBindings[port][0].HostIP = addrs[0]
+			for _, addr := range addrs[1:] {
+				portBindings[port] = append(portBindings[port], nat.PortBinding{
+					HostPort: strconv.Itoa(int(p.PublishedPort)),
+					HostIP:   addr,
+				})
+			}
+		}
 	}
 	hostConfig := &container.HostConfig{
 		CapAdd:       spec.Container.CapAdd,

--- a/pkg/api/port.go
+++ b/pkg/api/port.go
@@ -2,10 +2,12 @@ package api
 
 import (
 	"fmt"
+	"net"
 	"net/netip"
 	"slices"
 	"strconv"
 	"strings"
+	"unicode"
 )
 
 const (
@@ -23,6 +25,8 @@ type PortSpec struct {
 	Hostname string
 	// HostIP is the host IP to bind the PublishedPort to. Only valid in host mode.
 	HostIP netip.Addr
+	// Interface is the interface to bind the PublishedPort to. Only valid in host mode.
+	Interface net.Interface
 	// PublishedPort is the port number exposed outside the container.
 	// In ingress mode, this is the load balancer port. In host mode, this is the port bound on the host.
 	PublishedPort uint16
@@ -110,6 +114,9 @@ func (p *PortSpec) String() (string, error) {
 			} else {
 				parts = append(parts, p.HostIP.String())
 			}
+		}
+		if p.Interface.Name != "" {
+			parts = append(parts, p.Interface.Name)
 		}
 		parts = append(parts, fmt.Sprint(p.PublishedPort))
 		parts = append(parts, fmt.Sprint(p.ContainerPort))
@@ -211,7 +218,18 @@ func ParsePortSpec(port string) (PortSpec, error) {
 			}
 
 			if spec.HostIP, err = netip.ParseAddr(ip); err != nil {
-				return spec, fmt.Errorf("invalid host IP '%s': %w", parts[0], err)
+				// if single word, it's a interface name
+				ok := true
+				for _, c := range ip {
+					if !unicode.IsDigit(c) && !unicode.IsLetter(c) {
+						ok = false
+						break
+					}
+				}
+				if !ok {
+					return spec, fmt.Errorf("invalid host IP '%s': %w", parts[0], err)
+				}
+				spec.Interface.Name = ip
 			}
 		} else {
 			// Hostname may be empty.

--- a/pkg/client/compose/port.go
+++ b/pkg/client/compose/port.go
@@ -5,6 +5,7 @@ import (
 	"net/netip"
 	"strconv"
 	"strings"
+	"unicode"
 
 	"github.com/compose-spec/compose-go/v2/types"
 	"github.com/psviderski/uncloud/pkg/api"
@@ -112,10 +113,22 @@ func convertServicePortConfigToPortSpec(port types.ServicePortConfig) (api.PortS
 	// Set host IP if specified
 	if port.HostIP != "" {
 		hostIP, err := netip.ParseAddr(port.HostIP)
-		if err != nil {
-			return spec, fmt.Errorf("invalid host IP %q: %w", port.HostIP, err)
+		if err == nil {
+			spec.HostIP = hostIP
+		} else {
+			// A single word signalling a interface name.
+			ok := true
+			for _, c := range port.HostIP {
+				if !unicode.IsDigit(c) && !unicode.IsLetter(c) {
+					ok = false
+					break
+				}
+			}
+			if !ok {
+				return spec, fmt.Errorf("invalid host IP or interface name %q: %w", port.HostIP, err)
+			}
+			spec.Interface.Name = port.HostIP
 		}
-		spec.HostIP = hostIP
 	}
 
 	// Validate the resulting spec

--- a/pkg/client/compose/port_test.go
+++ b/pkg/client/compose/port_test.go
@@ -2,6 +2,7 @@ package compose
 
 import (
 	"context"
+	"net"
 	"net/netip"
 	"testing"
 
@@ -56,6 +57,15 @@ func TestConvertStandardPortsToPortSpecs(t *testing.T) {
 			},
 			expected: []api.PortSpec{
 				{ContainerPort: 8080, PublishedPort: 80, Protocol: "tcp", Mode: "host", HostIP: mustParseAddr("::1")},
+			},
+		},
+		{
+			name: "host interface",
+			ports: []types.ServicePortConfig{
+				{Target: 8080, Published: "80", Protocol: "tcp", HostIP: "enp1s0", Mode: "host"},
+			},
+			expected: []api.PortSpec{
+				{ContainerPort: 8080, PublishedPort: 80, Protocol: "tcp", Mode: "host", Interface: net.Interface{Name: "enp1s0"}},
 			},
 		},
 	}
@@ -211,7 +221,7 @@ func TestConvertServicePortConfigToPortSpec(t *testing.T) {
 			port: types.ServicePortConfig{
 				Target:    8080,
 				Published: "80",
-				HostIP:    "invalid",
+				HostIP:    "10.invalid",
 			},
 			wantErr: "invalid host IP",
 		},

--- a/website/docs/3-concepts/2-ingress/2-publishing-services.md
+++ b/website/docs/3-concepts/2-ingress/2-publishing-services.md
@@ -48,17 +48,20 @@ network interface(s). This is useful for non-HTTP services that need direct port
 [host_ip:]host_port:container_port[/protocol]@host
 ```
 
-- `host_ip` (optional): The IP address on the host to bind to. If omitted, binds to all interfaces.
+- `host_ip` (optional): The IP address on the host to bind to. If omitted, binds to all interfaces. If this is
+  not an IP address, it is interpreted as the interface and it will use all public IP addresses from that
+  interface.
 - `host_port`: The port number on the host to bind to.
 - `container_port`: The port number within the container that's listening for traffic.
 - `protocol` (optional): `tcp` or `udp` (default: `tcp`)
 
 | Port value                   | Description                                                                          |
-|------------------------------|--------------------------------------------------------------------------------------|
+| ---------------------------- | ------------------------------------------------------------------------------------ |
 | `8000/http`                  | Publish port 8000 as HTTP via Caddy using hostname `<service-name>.<cluster-domain>` |
 | `app.example.com:8080/https` | Publish port 8080 as HTTPS via Caddy using hostname `app.example.com`                |
 | `127.0.0.1:5432:5432@host`   | Bind TCP port 5432 to host port 5432 on loopback interface only                      |
 | `53:5353/udp@host`           | Bind UDP port 5353 to host port 53 on all network interfaces                         |
+| `ens1p0:53:5353/udp@host`    | Bind UDP port 5353 to host port 53 on the "ens1p0" interface                         |
 
 :::warning
 
@@ -78,8 +81,8 @@ services:
     image: app:latest
     x-ports:
       - example.com:8000/https
-      - www.example.com:8000/https  # The same port can be published with multiple hostnames
-      - api.domain.tld:9000/https   # Another port can be published with a different hostname
+      - www.example.com:8000/https # The same port can be published with multiple hostnames
+      - api.domain.tld:9000/https # Another port can be published with a different hostname
 ```
 
 ## Custom Caddy configuration
@@ -138,7 +141,7 @@ custom global configuration.
 The following functions and variables are available:
 
 | Template                              | Description                                                                                   |
-|---------------------------------------|-----------------------------------------------------------------------------------------------|
+| ------------------------------------- | --------------------------------------------------------------------------------------------- |
 | `{{upstreams [service-name] [port]}}` | A space-separated list of healthy container IPs for the current or specified service and port |
 | `{{.Name}}`                           | The name of the service the config belongs to                                                 |
 | `{{.Upstreams}}`                      | A map of all service names to their healthy container IPs                                     |
@@ -149,38 +152,49 @@ changes.
 **Examples:**
 
 1. Current service upstreams, default port:
+
    ```caddyfile
    reverse_proxy {{upstreams}}
    ```
+
    ↓
 
    ```caddyfile
    reverse_proxy 10.210.1.3 10.210.2.5
    ```
+
 2. Current service upstreams, port 8000:
+
    ```caddyfile
    reverse_proxy {{upstreams 8000}}
    ```
+
    ↓
 
    ```caddyfile
    reverse_proxy 10.210.1.3:8000 10.210.2.5:8000
    ```
+
 3. Current service upstreams with `https` scheme:
+
    ```caddyfile
    reverse_proxy {{- range $ip := index .Upstreams .Name}} https://{{$ip}}{{end}}
    ```
+
    ↓
 
    ```caddyfile
    reverse_proxy https://10.210.1.3 https://10.210.2.5
    ```
+
 4. `api` service upstreams, port 9000:
+
    ```caddyfile
    handle_path /api/* {
        reverse_proxy {{upstreams "api" 9000}}
    }
    ```
+
    ↓
 
    ```caddyfile

--- a/website/docs/8-compose-file-reference/2-extensions.md
+++ b/website/docs/8-compose-file-reference/2-extensions.md
@@ -106,7 +106,7 @@ services:
 ### Attributes
 
 | Attribute     | Type                    | Default         | Description                                                                                                                                                        |
-|---------------|-------------------------|-----------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| ------------- | ----------------------- | --------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | `command`     | string / list           | (required)      | The command to run in the hook container (same format as the service's [`command`](https://github.com/compose-spec/compose-spec/blob/main/05-services.md#command)) |
 | `environment` | map / list of KEY=VALUE | -               | Additional env vars that override or extend the service's [`environment`](https://github.com/compose-spec/compose-spec/blob/main/05-services.md#environment)       |
 | `privileged`  | bool                    | service's value | Override the service's [`privileged`](https://github.com/compose-spec/compose-spec/blob/main/05-services.md#privileged) mode                                       |

--- a/website/docs/9-cli-reference/uc_run.md
+++ b/website/docs/9-cli-reference/uc_run.md
@@ -29,7 +29,7 @@ uc run IMAGE [COMMAND...] [flags]
                             Examples:
                               -p 8080/https                  Publish port 8080 as HTTPS via reverse proxy with default service-name.cluster-domain hostname
                               -p app.example.com:8080/https  Publish port 8080 as HTTPS via reverse proxy with custom hostname
-                              -p 53:5353/udp@host            Bind UDP port 5353 to host port 53
+                              -p 53:5353/udp@host            Bind UDP port 5353 to host port 53  -p enp1s0:54:5454@host         Bind TCP port 5454 to host port 54 on interface enp1s0
       --pull string         Pull image from the registry before running service containers ('always', 'missing', 'never'). (default "missing")
       --replicas uint       Number of containers to run for the service. Only valid for a replicated service. (default 1)
       --shm-size bytes      Maximum amount of shared memory (mounted at /dev/shm) a service container can use. Value is a positive integer

--- a/website/docs/9-cli-reference/uc_service_run.md
+++ b/website/docs/9-cli-reference/uc_service_run.md
@@ -29,7 +29,7 @@ uc service run IMAGE [COMMAND...] [flags]
                             Examples:
                               -p 8080/https                  Publish port 8080 as HTTPS via reverse proxy with default service-name.cluster-domain hostname
                               -p app.example.com:8080/https  Publish port 8080 as HTTPS via reverse proxy with custom hostname
-                              -p 53:5353/udp@host            Bind UDP port 5353 to host port 53
+                              -p 53:5353/udp@host            Bind UDP port 5353 to host port 53  -p enp1s0:54:5454@host         Bind TCP port 5454 to host port 54 on interface enp1s0
       --pull string         Pull image from the registry before running service containers ('always', 'missing', 'never'). (default "missing")
       --replicas uint       Number of containers to run for the service. Only valid for a replicated service. (default 1)
       --shm-size bytes      Maximum amount of shared memory (mounted at /dev/shm) a service container can use. Value is a positive integer


### PR DESCRIPTION
feat: x-port add interface specification
When using x-ports in the host mode you can now also specify an
interface name. Uncloudd will when starting the container resolve the IP
address from that interface and use those to bind to.

When running a global service you may need this, as you can bind to IP
addresses these are obviously different on each machine. But using an
interface name this is more portable.

Fixes: https://github.com/psviderski/uncloud/issues/332

Signed-off-by: Miek Gieben <miek@miek.nl>