### PR TITLE
feat: add json output

### DIFF
--- a/cmd/uncloud/machine/ls.go
+++ b/cmd/uncloud/machine/ls.go
@@ -2,6 +2,7 @@ package machine
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"net/netip"
 	"strings"
@@ -12,20 +13,31 @@ import (
 	"github.com/spf13/cobra"
 )
 
+type listOptions struct {
+	json bool
+}
+
 func NewListCommand() *cobra.Command {
+	opts := listOptions{}
+
 	cmd := &cobra.Command{
 		Use:     "ls",
 		Aliases: []string{"list"},
 		Short:   "List machines in a cluster.",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			uncli := cmd.Context().Value("cli").(*cli.CLI)
-			return list(cmd.Context(), uncli)
+			return list(cmd.Context(), uncli, opts)
 		},
 	}
+
+	cmd.Flags().BoolVarP(&opts.json, "json", "j", false,
+		"Output JSON.",
+	)
+
 	return cmd
 }
 
-func list(ctx context.Context, uncli *cli.CLI) error {
+func list(ctx context.Context, uncli *cli.CLI, opts listOptions) error {
 	client, err := uncli.ConnectCluster(ctx)
 	if err != nil {
 		return fmt.Errorf("connect to cluster: %w", err)
@@ -66,6 +78,16 @@ func list(ctx context.Context, uncli *cli.CLI) error {
 			strings.Join(endpoints, tui.Faint.Render(", ")),
 			member.Machine.Id,
 		)
+	}
+
+	if opts.json {
+		type Machines struct {
+			Machines []map[string]string `json:"machines"`
+		}
+		machines := Machines{Machines: tui.TableToObjects(t)}
+		data, _ := json.MarshalIndent(machines, "", "  ")
+		fmt.Println(string(data))
+		return nil
 	}
 
 	fmt.Println(t)

--- a/cmd/uncloud/machine/ls.go
+++ b/cmd/uncloud/machine/ls.go
@@ -82,7 +82,7 @@ func list(ctx context.Context, uncli *cli.CLI, opts listOptions) error {
 
 	if opts.json {
 		type Machines struct {
-			Machines []map[string]string `json:"machines"`
+			Machines tui.Objects `json:"machines"`
 		}
 		machines := Machines{Machines: tui.TableToObjects(t)}
 		data, _ := json.MarshalIndent(machines, "", "  ")

--- a/internal/cli/tui/json.go
+++ b/internal/cli/tui/json.go
@@ -1,0 +1,62 @@
+package tui
+
+import (
+	"strings"
+	"unicode"
+
+	"charm.land/lipgloss/v2/table"
+)
+
+type Objects []map[string]string
+
+// TableToObjects convert the table to Objects that can then be used for json marshalling. Basic usage:
+//
+//	 type Machines struct { // define a wrapper type
+//		 Machines []map[string]string `json:"machines"`
+//	 }
+//
+//	 machines := Machines{Machines: tui.TableToObjects(t)} // convert the table
+//	 data, _ := json.MarshalIndent(machines, "", "  ") // marshal to json
+//	 fmt.Println(string(data)) // output
+func TableToObjects(t *table.Table) Objects {
+	rows := table.DataToMatrix(t.GetData())
+	headers := t.GetHeaders()
+	objects := make(Objects, len(rows))
+
+	for i, row := range rows {
+		obj := make(map[string]string)
+		for j, val := range row {
+			obj[camelcase(headers[j])] = val
+		}
+		objects[i] = obj
+	}
+
+	return objects
+}
+
+// camelcase returns a strings the is camel cased for use as JSON keys.
+func camelcase(s string) string {
+	if len(s) == 0 {
+		return ""
+	}
+	if len(s) == 1 {
+		return strings.ToLower(s)
+	}
+
+	sb := strings.Builder{}
+	transform := unicode.ToLower
+	for i, r := range s {
+		if i == 0 {
+			sb.WriteRune(unicode.ToLower(r))
+			continue
+		}
+		if unicode.IsSpace(r) {
+			transform = unicode.ToUpper
+			continue
+		}
+
+		sb.WriteRune(transform(r))
+		transform = unicode.ToLower
+	}
+	return sb.String()
+}

--- a/internal/cli/tui/json.go
+++ b/internal/cli/tui/json.go
@@ -9,7 +9,7 @@ import (
 
 type Objects []map[string]string
 
-// TableToObjects convert the table to Objects that can then be used for json marshalling. Basic usage:
+// TableToObjects converts the table to Objects that can then be used for json marshalling. Basic usage:
 //
 //	 type Machines struct { // define a wrapper type
 //		 Machines []map[string]string `json:"machines"`
@@ -34,7 +34,8 @@ func TableToObjects(t *table.Table) Objects {
 	return objects
 }
 
-// camelcase returns a strings the is camel cased for use as JSON keys.
+// camelcase returns a string that is camelCased for use as a JSON key, i.e. "WIREGUARD ENDPOINT" - usually
+// the input is all capitals, becomes wireguardEndpoint.
 func camelcase(s string) string {
 	if len(s) == 0 {
 		return ""


### PR DESCRIPTION
This adds the option to have json output. It currently only does this for `machine ls`, but if approved this will be extended to all list commands.

It works of the table.Table as that is the expected output and converts it back to a structure that can be json Marshalled for outputting. See json.go.

No effort is done to convert "MACHINE ID" into machineID, it's machineId in the json output.

For example it looks normally like this:

```
% uc machine ls
NAME           STATE   ADDRESS         PUBLIC IP       WIREGUARD ENDPOINTS   MACHINE ID
machine-781l   Up      10.210.0.1/24   131.174.88.77   131.174.88.77:51820   c22073beee04bf9b1861e53c21023d2d
machine-9q7y   Up      10.210.1.1/24   131.174.88.78   131.174.88.78:51820   212fd73438b53ebfb7dd531da4c6ed41
```

and this as --json

```
% uc machine ls --json
{
  "machines": [
    {
      "address": "10.210.0.1/24",
      "machineId": "c22073beee04bf9b1861e53c21023d2d",
      "name": "machine-781l",
      "publicIp": "131.174.88.77",
      "state": "Up",
      "wireguardEndpoints": "131.174.88.77:51820"
    },
    {
      "address": "10.210.1.1/24",
      "machineId": "212fd73438b53ebfb7dd531da4c6ed41",
      "name": "machine-9q7y",
      "publicIp": "131.174.88.78",
      "state": "Up",
      "wireguardEndpoints": "131.174.88.78:51820"
    }
  ]
}

```

Fixes: #335