### PR TITLE
feat: add completion for ucind

### DIFF
--- a/cmd/ucind/cluster/remove.go
+++ b/cmd/ucind/cluster/remove.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/psviderski/uncloud/internal/ucind"
+	"github.com/psviderski/uncloud/internal/ucind/completion"
 	"github.com/spf13/cobra"
 )
 
@@ -25,6 +26,12 @@ func NewRemoveCommand() *cobra.Command {
 			}
 			fmt.Printf("Cluster '%s' removed.\n", name)
 			return nil
+		},
+		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]cobra.Completion, cobra.ShellCompDirective) {
+			if len(args) > 0 {
+				return nil, cobra.ShellCompDirectiveNoFileComp
+			}
+			return completion.Clusters(cmd, args, toComplete)
 		},
 	}
 	return cmd

--- a/internal/ucind/completion/cluster.go
+++ b/internal/ucind/completion/cluster.go
@@ -1,0 +1,29 @@
+// Package completion implements completion functions for the ucind cli.
+package completion
+
+import (
+	"slices"
+	"strings"
+
+	"github.com/psviderski/uncloud/internal/ucind"
+	"github.com/spf13/cobra"
+)
+
+func Clusters(cmd *cobra.Command, args []string, toComplete string) ([]cobra.Completion, cobra.ShellCompDirective) {
+	p := cmd.Context().Value("provisioner").(*ucind.Provisioner)
+	clusters, err := p.ListClusters(cmd.Context())
+	if err != nil {
+		return nil, cobra.ShellCompDirectiveError
+	}
+
+	names := []cobra.Completion{}
+	for _, cluster := range clusters {
+		if slices.Contains(args, cluster.Name) {
+			continue
+		}
+		if strings.HasPrefix(cluster.Name, toComplete) {
+			names = append(names, cluster.Name)
+		}
+	}
+	return names, cobra.ShellCompDirectiveNoFileComp
+}


### PR DESCRIPTION
For feature parity with uc. Only _really_ usefull for ucind cluster rm, but still useful, and not many lines of code.