### PR TITLE
chore: completion add machine completion for log -m too

### DIFF
--- a/cmd/uncloud/machine/logs.go
+++ b/cmd/uncloud/machine/logs.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/psviderski/uncloud/internal/cli"
+	"github.com/psviderski/uncloud/internal/cli/completion"
 	"github.com/psviderski/uncloud/internal/cli/logs"
 	"github.com/psviderski/uncloud/internal/journal"
 	"github.com/psviderski/uncloud/pkg/api"
@@ -56,6 +57,8 @@ If no services are specified, streams logs from the uncloud service.`,
 	}
 
 	cmd.Flags().AddFlagSet(logs.Flags(&options))
+	completion.MachinesFlag(cmd)
+
 	return cmd
 }
 

--- a/cmd/uncloud/service/logs.go
+++ b/cmd/uncloud/service/logs.go
@@ -74,8 +74,6 @@ If no services are specified, streams logs from all services defined in the Comp
 	cmd.Flags().AddFlagSet(logs.Flags(&options))
 	completion.MachinesFlag(cmd)
 
-	completion.MachinesFlag(cmd)
-
 	return cmd
 }
 


### PR DESCRIPTION
machine/logs.go didn't have -m <machine> completion. service/logs.go called complation.MachinesFlag(..) twice.