### PR TITLE
feat: error when using relative volumes sources in compose

### DIFF
--- a/pkg/client/compose/project.go
+++ b/pkg/client/compose/project.go
@@ -129,9 +129,9 @@ func checkRelativeVolumeMount(data any, _ tree.Path, _ bool) (any, error) {
 	}
 	if strings.HasPrefix(source, "./") || strings.HasPrefix(source, "../") { // only check actual paths, not volumes _names_
 		// uc run also warns against this
-		tui.PrintWarning("Invalid volume mount, volume name '" + source + "' is relative. If you intended to pass a host " +
-			"host directory or file, use absolute path, or configs might be better suited for this use case. " +
-			"See https://docs.docker.com/reference/compose-file/configs/")
+		return nil, fmt.Errorf("invalid volume mount, volume name '%s' is relative. If you intended to pass a host "+
+			"host directory or file, use absolute path, or configs might be better suited for this use case. "+
+			"See https://docs.docker.com/reference/compose-file/configs/", source)
 	}
 
 	return data, nil

--- a/pkg/client/compose/project.go
+++ b/pkg/client/compose/project.go
@@ -22,6 +22,7 @@ var registerComposeOverrides sync.Once
 func LoadProject(ctx context.Context, paths []string, opts ...composecli.ProjectOptionsFn) (*types.Project, error) {
 	registerComposeOverrides.Do(func() {
 		transform.RegisterDefaultValue("services.*.deploy.update_config", setUpdateConfigDefaults)
+		transform.RegisterDefaultValue("services.*.volumes.*.source", checkRelativeVolumeMount)
 	})
 
 	defaultOpts := []composecli.ProjectOptionsFn{
@@ -117,5 +118,21 @@ func setUpdateConfigDefaults(data any, _ tree.Path, _ bool) (any, error) {
 			v["monitor"] = api.DefaultHealthMonitorPeriod.String()
 		}
 	}
+	return data, nil
+}
+
+// checkRelativeVolumeMount check if a volume mount uses a relative path.
+func checkRelativeVolumeMount(data any, _ tree.Path, _ bool) (any, error) {
+	source, ok := data.(string)
+	if !ok || filepath.IsAbs(source) {
+		return data, nil
+	}
+	if strings.HasPrefix(source, "./") || strings.HasPrefix(source, "../") { // only check actual paths, not volumes _names_
+		// uc run also warns against this
+		tui.PrintWarning("Invalid volume mount, volume name '" + source + "' is relative. If you intended to pass a host " +
+			"host directory or file, use absolute path, or configs might be better suited for this use case. " +
+			"See https://docs.docker.com/reference/compose-file/configs/")
+	}
+
 	return data, nil
 }

--- a/pkg/client/compose/project.go
+++ b/pkg/client/compose/project.go
@@ -127,11 +127,12 @@ func checkRelativeVolumeMount(data any, _ tree.Path, _ bool) (any, error) {
 	if !ok || filepath.IsAbs(source) {
 		return data, nil
 	}
-	if strings.HasPrefix(source, "./") || strings.HasPrefix(source, "../") { // only check actual paths, not volumes _names_
+	// Only check actual paths, not volumes _names_
+	if strings.HasPrefix(source, "./") || strings.HasPrefix(source, "../") {
 		// uc run also warns against this
-		return nil, fmt.Errorf("invalid volume mount, volume name '%s' is relative. If you intended to pass a host "+
-			"host directory or file, use absolute path, or configs might be better suited for this use case. "+
-			"See https://docs.docker.com/reference/compose-file/configs/", source)
+		return nil, fmt.Errorf("invalid volume mount: volume name '%s' is relative. If you intended to pass a host "+
+			"directory or file, use absolute path, or configs might be better suited for this use case. "+
+			"See https://uncloud.run/docs/concepts/configs", source)
 	}
 
 	return data, nil

--- a/pkg/client/compose/project.go
+++ b/pkg/client/compose/project.go
@@ -128,9 +128,9 @@ func checkRelativeVolumeMount(data any, _ tree.Path, _ bool) (any, error) {
 		return data, nil
 	}
 	// Only check actual paths, not volumes _names_
-	if strings.HasPrefix(source, "./") || strings.HasPrefix(source, "../") {
+	if strings.HasPrefix(source, ".") || strings.HasPrefix(source, "~") {
 		// uc run also warns against this
-		return nil, fmt.Errorf("invalid volume mount: volume name '%s' is relative. If you intended to pass a host "+
+		return nil, fmt.Errorf("invalid volume mount: bind mount source '%s' is relative. If you intended to pass a host "+
 			"directory or file, use absolute path, or configs might be better suited for this use case. "+
 			"See https://uncloud.run/docs/concepts/configs", source)
 	}

--- a/pkg/client/compose/project_test.go
+++ b/pkg/client/compose/project_test.go
@@ -296,6 +296,20 @@ networks:
 `,
 			warnCount: 0,
 		},
+		{
+			name: "relative volume sources",
+			composeYAML: `services:
+  app:
+    image: myapp:latest
+    volumes:
+      - ./mypath/conf:/conf:ro
+      - data:/var/lib/data
+
+volumes:
+  data:
+`,
+			warnCount: 1,
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/client/compose/project_test.go
+++ b/pkg/client/compose/project_test.go
@@ -189,7 +189,7 @@ REDIS_URL=redis://localhost:6379
 	}
 }
 
-// TestLoadProject_Unsupported checks that unsupported features lead to warnings.
+// TestLoadProject_Unsupported checks that unsupported features lead to warnings or errors.
 func TestLoadProject_Unsupported(t *testing.T) {
 	// captureStderr runs fn while capturing stderr output and returns what was written.
 	captureStderr := func(t *testing.T, fn func()) string {
@@ -214,6 +214,7 @@ func TestLoadProject_Unsupported(t *testing.T) {
 		composeYAML  string
 		warnCount    int
 		warnContains []string
+		shouldErr    bool
 	}{
 		{
 			name: "unsupported dns",
@@ -308,7 +309,7 @@ networks:
 volumes:
   data:
 `,
-			warnCount: 1,
+			shouldErr: true,
 		},
 	}
 
@@ -316,6 +317,10 @@ volumes:
 		t.Run(tt.name, func(t *testing.T) {
 			stderr := captureStderr(t, func() {
 				_, err := LoadProjectFromContent(context.Background(), tt.composeYAML)
+				if tt.shouldErr {
+					require.Error(t, err)
+					return
+				}
 				require.NoError(t, err)
 			})
 

--- a/pkg/client/compose/project_test.go
+++ b/pkg/client/compose/project_test.go
@@ -311,6 +311,16 @@ volumes:
 `,
 			shouldErr: true,
 		},
+		{
+			name: "home-relative volume source",
+			composeYAML: `services:
+  app:
+    image: myapp:latest
+    volumes:
+      - ~/conf:/conf:ro
+`,
+			shouldErr: true,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Add a warning when using compose with a relative volume source, as this like does not do what you want.

Warning:
```
WARNING: Invalid volume mount, volume name './atomdns' is relative. If you intended to pass a host host directory or file,
use absolute path, or configs might be better suited for this use case. See https://docs.docker.com/reference/compose-file/configs/
```

This warning is slightly amended from `uc run` which straight up disallows these kind of paths:

```
Error: invalid volume mount './atomdns:/conf:ro': volume name './atomdns'
includes invalid characters, only '[a-zA-Z0-9][a-zA-Z0-9_.-]' are allowed. If you intended to pass a host directory or file, use absolute path
```

Fixes: #346