### PR TITLE
feat: add status column to uc ls

### DIFF
--- a/cmd/uncloud/service/ls.go
+++ b/cmd/uncloud/service/ls.go
@@ -52,7 +52,7 @@ func list(ctx context.Context, uncli *cli.CLI) error {
 	t := tui.NewTable()
 
 	// Include the ID column if there are duplicate service names to differentiate them.
-	headers := []string{"NAME", "MODE", "REPLICAS", "IMAGE", "ENDPOINTS"}
+	headers := []string{"NAME", "MODE", "REPLICAS", "IMAGE", "ENDPOINTS", "STATUS"}
 	if haveDuplicateNames {
 		headers = append([]string{"ID"}, headers...)
 	}
@@ -75,7 +75,15 @@ func list(ctx context.Context, uncli *cli.CLI) error {
 			}
 		}
 
-		row := []string{s.Name, s.Mode, fmt.Sprintf("%d", len(s.Containers)), formattedImages, endpoints}
+		healthy := 0
+		for _, ctr := range s.Containers {
+			if ctr.Container.Healthy() {
+				healthy++
+			}
+		}
+		status := fmt.Sprintf("%d/%d healthy", healthy, len(s.Containers))
+
+		row := []string{s.Name, s.Mode, fmt.Sprintf("%d", len(s.Containers)), formattedImages, endpoints, status}
 		if haveDuplicateNames {
 			row = append([]string{s.ID}, row...)
 		}


### PR DESCRIPTION
This adds a status colunm showing the state of each container in the service. It lists x/y health, where x is the healthy container and y the total number:

~~~
NAME            MODE         REPLICAS   IMAGE                                                  ENDPOINTS                                         STATUS
atomdns         replicated   1          registry.science.ru.nl/cncz/sys/image/atomdns:latest   https://ctrl.u.science.ru.nl → :443               0/1 healthy
caddy           global       2          registry.science.ru.nl/cncz/sys/image/caddy:latest     (custom Caddy config)                             2/2 healthy
debian-vvsd     replicated   1          debian:bookworm-slim                                                                                     0/1 healthy
debug           replicated   1          registry.science.ru.nl/cncz/sys/image/debug:latest                                                       1/1 healthy
kopia           global       2          registry.science.ru.nl/cncz/sys/image/kopia:latest                                                       2/2 healthy
~~~

Fixes: #13

(Wasn't aware atomdns is crash-looping)