### PR TITLE
feat: uc run --entrypoint: allow comma-separated

### DIFF
--- a/cmd/uncloud/service/run.go
+++ b/cmd/uncloud/service/run.go
@@ -22,7 +22,7 @@ type runOptions struct {
 	caddyfile         string
 	command           []string
 	cpu               dockeropts.NanoCPUs
-	entrypoint        string
+	entrypoint        []string
 	entrypointChanged bool
 	env               []string
 	image             string
@@ -67,8 +67,9 @@ func NewRunCommand(groupID string) *cobra.Command {
 	cmd.Flags().VarP(&opts.cpu, "cpu", "",
 		"Maximum number of CPU cores a service container can use. Fractional values are allowed: "+
 			"0.5 for half a core or 2.25 for two and a quarter cores.")
-	cmd.Flags().StringVar(&opts.entrypoint, "entrypoint", "",
-		"Overwrite the default ENTRYPOINT of the image. Pass an empty string \"\" to reset it.")
+	cmd.Flags().StringSliceVar(&opts.entrypoint, "entrypoint", nil,
+		"Overwrite the default ENTRYPOINT of the image. Pass an empty string \"\" to reset it. Can be specified "+
+			"multiple times or as a comma-separated list of command and arguments.")
 	cmd.Flags().StringSliceVarP(&opts.env, "env", "e", nil,
 		"Set an environment variable for service containers. Can be specified multiple times.\n"+
 			"Format: VAR=value or just VAR to use the value from the local environment.")
@@ -255,8 +256,8 @@ func prepareServiceSpec(opts runOptions) (api.ServiceSpec, error) {
 	}
 
 	// Overwrite the default ENTRYPOINT of the image or reset it if an empty string is passed.
-	if opts.entrypoint != "" {
-		spec.Container.Entrypoint = []string{opts.entrypoint}
+	if opts.entrypoint != nil {
+		spec.Container.Entrypoint = cli.ExpandCommaSeparatedValues(opts.entrypoint)
 	} else if opts.entrypointChanged {
 		spec.Container.Entrypoint = []string{""}
 	}

--- a/website/docs/9-cli-reference/uc_run.md
+++ b/website/docs/9-cli-reference/uc_run.md
@@ -9,46 +9,46 @@ uc run IMAGE [COMMAND...] [flags]
 ## Options
 
 ```
-      --caddyfile string    Path to a custom Caddy config (Caddyfile) for the service. Cannot be used together with non-@host published ports.
-      --cpu decimal         Maximum number of CPU cores a service container can use. Fractional values are allowed: 0.5 for half a core or 2.25 for two and a quarter cores.
-      --entrypoint string   Overwrite the default ENTRYPOINT of the image. Pass an empty string "" to reset it.
-  -e, --env strings         Set an environment variable for service containers. Can be specified multiple times.
-                            Format: VAR=value or just VAR to use the value from the local environment.
-  -h, --help                help for run
-  -m, --machine strings     Placement constraint by machine names, limiting which machines the service can run on. Can be specified multiple times or as a comma-separated list of machine names. (default is any suitable machine)
-      --memory bytes        Maximum amount of memory a service container can use. Value is a positive integer with optional unit suffix (b, k, m, g).
-                            Default unit is bytes if no suffix specified.
-                            Examples: 1073741824, 1024m, 1g (all equal 1 gibibyte)
-      --mode string         Replication mode of the service: either 'replicated' (a specified number of containers across the machines) or 'global' (one container on every machine). (default "replicated")
-  -n, --name string         Assign a name to the service. A random name is generated if not specified.
-      --privileged          Give extended privileges to service containers. This is a security risk and should be used with caution.
-  -p, --publish strings     Publish a service port to make it accessible outside the cluster. Can be specified multiple times.
-                            Format: [hostname:]container_port[/protocol] or [host_ip:]host_port:container_port[/protocol]@host
-                            Supported protocols: tcp, udp, http, https (default is tcp). If a hostname for http(s) port is not specified
-                            and a cluster domain is reserved, service-name.cluster-domain will be used as the hostname.
-                            Examples:
-                              -p 8080/https                  Publish port 8080 as HTTPS via reverse proxy with default service-name.cluster-domain hostname
-                              -p app.example.com:8080/https  Publish port 8080 as HTTPS via reverse proxy with custom hostname
-                              -p 53:5353/udp@host            Bind UDP port 5353 to host port 53
-      --pull string         Pull image from the registry before running service containers ('always', 'missing', 'never'). (default "missing")
-      --replicas uint       Number of containers to run for the service. Only valid for a replicated service. (default 1)
-      --shm-size bytes      Maximum amount of shared memory (mounted at /dev/shm) a service container can use. Value is a positive integer
-                            with optional unit suffix (b, k, m, g). Default unit is bytes if no suffix specified.
-                            Examples: 1073741824, 1024m, 1g (all equal 1 gibibyte)
-      --ulimit strings      Set resource limits for service containers. Can be specified multiple times.
-                            Format: type=soft_limit[:hard_limit]. If hard limit is not specified, soft limit is used for both.
-                            Examples:
-                              --ulimit nofile=1024:2048  Set soft limit to 1024 and hard limit to 2048 for number of open files
-                              --ulimit nproc=65535       Set both soft and hard limits to 65535 for number of processes
-  -u, --user string         User name or UID and optionally group name or GID used for running the command inside service containers.
-                            Format: USER[:GROUP] or UID[:GID]. If not specified, the user is set to the default user of the image.
-  -v, --volume strings      Mount a data volume or host path into service containers. Service containers will be scheduled on the machine(s) where
-                            the volume is located. Can be specified multiple times.
-                            Format: volume_name:/container/path[:ro|volume-nocopy] or /host/path:/container/path[:ro]
-                            Examples:
-                              -v postgres-data:/var/lib/postgresql/data  Mount volume 'postgres-data' to /var/lib/postgresql/data in container
-                              -v /data/uploads:/app/uploads         	 Bind mount /data/uploads host directory to /app/uploads in container
-                              -v /host/path:/container/path:ro 		 Bind mount a host directory or file as read-only
+      --caddyfile string     Path to a custom Caddy config (Caddyfile) for the service. Cannot be used together with non-@host published ports.
+      --cpu decimal          Maximum number of CPU cores a service container can use. Fractional values are allowed: 0.5 for half a core or 2.25 for two and a quarter cores.
+      --entrypoint strings   Overwrite the default ENTRYPOINT of the image. Pass an empty string "" to reset it. Can be specified multiple times or as a comma-separated list of command and arguments.
+  -e, --env strings          Set an environment variable for service containers. Can be specified multiple times.
+                             Format: VAR=value or just VAR to use the value from the local environment.
+  -h, --help                 help for run
+  -m, --machine strings      Placement constraint by machine names, limiting which machines the service can run on. Can be specified multiple times or as a comma-separated list of machine names. (default is any suitable machine)
+      --memory bytes         Maximum amount of memory a service container can use. Value is a positive integer with optional unit suffix (b, k, m, g).
+                             Default unit is bytes if no suffix specified.
+                             Examples: 1073741824, 1024m, 1g (all equal 1 gibibyte)
+      --mode string          Replication mode of the service: either 'replicated' (a specified number of containers across the machines) or 'global' (one container on every machine). (default "replicated")
+  -n, --name string          Assign a name to the service. A random name is generated if not specified.
+      --privileged           Give extended privileges to service containers. This is a security risk and should be used with caution.
+  -p, --publish strings      Publish a service port to make it accessible outside the cluster. Can be specified multiple times.
+                             Format: [hostname:]container_port[/protocol] or [host_ip:]host_port:container_port[/protocol]@host
+                             Supported protocols: tcp, udp, http, https (default is tcp). If a hostname for http(s) port is not specified
+                             and a cluster domain is reserved, service-name.cluster-domain will be used as the hostname.
+                             Examples:
+                               -p 8080/https                  Publish port 8080 as HTTPS via reverse proxy with default service-name.cluster-domain hostname
+                               -p app.example.com:8080/https  Publish port 8080 as HTTPS via reverse proxy with custom hostname
+                               -p 53:5353/udp@host            Bind UDP port 5353 to host port 53
+      --pull string          Pull image from the registry before running service containers ('always', 'missing', 'never'). (default "missing")
+      --replicas uint        Number of containers to run for the service. Only valid for a replicated service. (default 1)
+      --shm-size bytes       Maximum amount of shared memory (mounted at /dev/shm) a service container can use. Value is a positive integer
+                             with optional unit suffix (b, k, m, g). Default unit is bytes if no suffix specified.
+                             Examples: 1073741824, 1024m, 1g (all equal 1 gibibyte)
+      --ulimit strings       Set resource limits for service containers. Can be specified multiple times.
+                             Format: type=soft_limit[:hard_limit]. If hard limit is not specified, soft limit is used for both.
+                             Examples:
+                               --ulimit nofile=1024:2048  Set soft limit to 1024 and hard limit to 2048 for number of open files
+                               --ulimit nproc=65535       Set both soft and hard limits to 65535 for number of processes
+  -u, --user string          User name or UID and optionally group name or GID used for running the command inside service containers.
+                             Format: USER[:GROUP] or UID[:GID]. If not specified, the user is set to the default user of the image.
+  -v, --volume strings       Mount a data volume or host path into service containers. Service containers will be scheduled on the machine(s) where
+                             the volume is located. Can be specified multiple times.
+                             Format: volume_name:/container/path[:ro|volume-nocopy] or /host/path:/container/path[:ro]
+                             Examples:
+                               -v postgres-data:/var/lib/postgresql/data  Mount volume 'postgres-data' to /var/lib/postgresql/data in container
+                               -v /data/uploads:/app/uploads         	 Bind mount /data/uploads host directory to /app/uploads in container
+                               -v /host/path:/container/path:ro 		 Bind mount a host directory or file as read-only
 ```
 
 ## Options inherited from parent commands

--- a/website/docs/9-cli-reference/uc_service_run.md
+++ b/website/docs/9-cli-reference/uc_service_run.md
@@ -9,46 +9,46 @@ uc service run IMAGE [COMMAND...] [flags]
 ## Options
 
 ```
-      --caddyfile string    Path to a custom Caddy config (Caddyfile) for the service. Cannot be used together with non-@host published ports.
-      --cpu decimal         Maximum number of CPU cores a service container can use. Fractional values are allowed: 0.5 for half a core or 2.25 for two and a quarter cores.
-      --entrypoint string   Overwrite the default ENTRYPOINT of the image. Pass an empty string "" to reset it.
-  -e, --env strings         Set an environment variable for service containers. Can be specified multiple times.
-                            Format: VAR=value or just VAR to use the value from the local environment.
-  -h, --help                help for run
-  -m, --machine strings     Placement constraint by machine names, limiting which machines the service can run on. Can be specified multiple times or as a comma-separated list of machine names. (default is any suitable machine)
-      --memory bytes        Maximum amount of memory a service container can use. Value is a positive integer with optional unit suffix (b, k, m, g).
-                            Default unit is bytes if no suffix specified.
-                            Examples: 1073741824, 1024m, 1g (all equal 1 gibibyte)
-      --mode string         Replication mode of the service: either 'replicated' (a specified number of containers across the machines) or 'global' (one container on every machine). (default "replicated")
-  -n, --name string         Assign a name to the service. A random name is generated if not specified.
-      --privileged          Give extended privileges to service containers. This is a security risk and should be used with caution.
-  -p, --publish strings     Publish a service port to make it accessible outside the cluster. Can be specified multiple times.
-                            Format: [hostname:]container_port[/protocol] or [host_ip:]host_port:container_port[/protocol]@host
-                            Supported protocols: tcp, udp, http, https (default is tcp). If a hostname for http(s) port is not specified
-                            and a cluster domain is reserved, service-name.cluster-domain will be used as the hostname.
-                            Examples:
-                              -p 8080/https                  Publish port 8080 as HTTPS via reverse proxy with default service-name.cluster-domain hostname
-                              -p app.example.com:8080/https  Publish port 8080 as HTTPS via reverse proxy with custom hostname
-                              -p 53:5353/udp@host            Bind UDP port 5353 to host port 53
-      --pull string         Pull image from the registry before running service containers ('always', 'missing', 'never'). (default "missing")
-      --replicas uint       Number of containers to run for the service. Only valid for a replicated service. (default 1)
-      --shm-size bytes      Maximum amount of shared memory (mounted at /dev/shm) a service container can use. Value is a positive integer
-                            with optional unit suffix (b, k, m, g). Default unit is bytes if no suffix specified.
-                            Examples: 1073741824, 1024m, 1g (all equal 1 gibibyte)
-      --ulimit strings      Set resource limits for service containers. Can be specified multiple times.
-                            Format: type=soft_limit[:hard_limit]. If hard limit is not specified, soft limit is used for both.
-                            Examples:
-                              --ulimit nofile=1024:2048  Set soft limit to 1024 and hard limit to 2048 for number of open files
-                              --ulimit nproc=65535       Set both soft and hard limits to 65535 for number of processes
-  -u, --user string         User name or UID and optionally group name or GID used for running the command inside service containers.
-                            Format: USER[:GROUP] or UID[:GID]. If not specified, the user is set to the default user of the image.
-  -v, --volume strings      Mount a data volume or host path into service containers. Service containers will be scheduled on the machine(s) where
-                            the volume is located. Can be specified multiple times.
-                            Format: volume_name:/container/path[:ro|volume-nocopy] or /host/path:/container/path[:ro]
-                            Examples:
-                              -v postgres-data:/var/lib/postgresql/data  Mount volume 'postgres-data' to /var/lib/postgresql/data in container
-                              -v /data/uploads:/app/uploads         	 Bind mount /data/uploads host directory to /app/uploads in container
-                              -v /host/path:/container/path:ro 		 Bind mount a host directory or file as read-only
+      --caddyfile string     Path to a custom Caddy config (Caddyfile) for the service. Cannot be used together with non-@host published ports.
+      --cpu decimal          Maximum number of CPU cores a service container can use. Fractional values are allowed: 0.5 for half a core or 2.25 for two and a quarter cores.
+      --entrypoint strings   Overwrite the default ENTRYPOINT of the image. Pass an empty string "" to reset it. Can be specified multiple times or as a comma-separated list of command and arguments.
+  -e, --env strings          Set an environment variable for service containers. Can be specified multiple times.
+                             Format: VAR=value or just VAR to use the value from the local environment.
+  -h, --help                 help for run
+  -m, --machine strings      Placement constraint by machine names, limiting which machines the service can run on. Can be specified multiple times or as a comma-separated list of machine names. (default is any suitable machine)
+      --memory bytes         Maximum amount of memory a service container can use. Value is a positive integer with optional unit suffix (b, k, m, g).
+                             Default unit is bytes if no suffix specified.
+                             Examples: 1073741824, 1024m, 1g (all equal 1 gibibyte)
+      --mode string          Replication mode of the service: either 'replicated' (a specified number of containers across the machines) or 'global' (one container on every machine). (default "replicated")
+  -n, --name string          Assign a name to the service. A random name is generated if not specified.
+      --privileged           Give extended privileges to service containers. This is a security risk and should be used with caution.
+  -p, --publish strings      Publish a service port to make it accessible outside the cluster. Can be specified multiple times.
+                             Format: [hostname:]container_port[/protocol] or [host_ip:]host_port:container_port[/protocol]@host
+                             Supported protocols: tcp, udp, http, https (default is tcp). If a hostname for http(s) port is not specified
+                             and a cluster domain is reserved, service-name.cluster-domain will be used as the hostname.
+                             Examples:
+                               -p 8080/https                  Publish port 8080 as HTTPS via reverse proxy with default service-name.cluster-domain hostname
+                               -p app.example.com:8080/https  Publish port 8080 as HTTPS via reverse proxy with custom hostname
+                               -p 53:5353/udp@host            Bind UDP port 5353 to host port 53
+      --pull string          Pull image from the registry before running service containers ('always', 'missing', 'never'). (default "missing")
+      --replicas uint        Number of containers to run for the service. Only valid for a replicated service. (default 1)
+      --shm-size bytes       Maximum amount of shared memory (mounted at /dev/shm) a service container can use. Value is a positive integer
+                             with optional unit suffix (b, k, m, g). Default unit is bytes if no suffix specified.
+                             Examples: 1073741824, 1024m, 1g (all equal 1 gibibyte)
+      --ulimit strings       Set resource limits for service containers. Can be specified multiple times.
+                             Format: type=soft_limit[:hard_limit]. If hard limit is not specified, soft limit is used for both.
+                             Examples:
+                               --ulimit nofile=1024:2048  Set soft limit to 1024 and hard limit to 2048 for number of open files
+                               --ulimit nproc=65535       Set both soft and hard limits to 65535 for number of processes
+  -u, --user string          User name or UID and optionally group name or GID used for running the command inside service containers.
+                             Format: USER[:GROUP] or UID[:GID]. If not specified, the user is set to the default user of the image.
+  -v, --volume strings       Mount a data volume or host path into service containers. Service containers will be scheduled on the machine(s) where
+                             the volume is located. Can be specified multiple times.
+                             Format: volume_name:/container/path[:ro|volume-nocopy] or /host/path:/container/path[:ro]
+                             Examples:
+                               -v postgres-data:/var/lib/postgresql/data  Mount volume 'postgres-data' to /var/lib/postgresql/data in container
+                               -v /data/uploads:/app/uploads         	 Bind mount /data/uploads host directory to /app/uploads in container
+                               -v /host/path:/container/path:ro 		 Bind mount a host directory or file as read-only
 ```
 
 ## Options inherited from parent commands


### PR DESCRIPTION
Allow comma-separated values in uc run --entrypoint.

```
% uc run --entrypoint /bin/sleep,infinity debian:bookworm-slim
[+] Running service debian-mc7z (replicated mode) 3/3
 ✔ Container debian-mc7z-igok on machine-781l  Running              7.5s
   ✔ Image debian:bookworm-slim on machine-781l  Pulled             2.1s
% uc ls
NAME            MODE         REPLICAS   IMAGE                                                  ENDPOINTS
debian-mc7z     replicated   1          debian:bookworm-slim

Fixes: #360