### PR TITLE
goreleaser: build uc instead of uncloud

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -22,7 +22,7 @@ snapshot:
 builds:
   - id: uncloud
     main: ./cmd/uncloud
-    binary: uncloud
+    binary: uc
     env:
       # Use CGO to be able to build fsevent required by compose on macOS.
       - CGO_ENABLED={{ if eq .Os "darwin" }}1{{ else }}0{{ end }}


### PR DESCRIPTION
Fixes: #367

Seems to build the right thing as shown below:
(obvs can't test in production)

```sh
[1] % GOOS="linux" \
GOARCH="arm64" \
/tmp/goreleaser build --single-target --snapshot --clean
  • skipping validate...
  • cleaning distribution directory
  • loading environment variables
  • getting and validating git state
    • ignoring errors because this is a snapshot     error=git doesn't contain any tags - either add a tag or use --snapshot
    • using tags                                     previous=<unknown> current=v0.0.0
    • pipe skipped or partially skipped              reason=disabled during snapshot mode
  • parsing tag
  • setting defaults
    • DEPRECATED: archives.builds should not be used anymore, check https://goreleaser.com/deprecations#archivesbuilds for more info
    • brews is being phased out in favor of homebrew_casks, check https://goreleaser.com/deprecations#brews for more info
  • partial
  • snapshotting
    • building snapshot...                           version=0.1.0-nightly-519825c
  • running before hooks
    • running                                        hook=go mod tidy
  • ensuring distribution directory
  • setting up metadata
  • writing release metadata
  • loading go mod information
  • build prerequisites
  • building binaries
    • partial build                                  match=target=linux_arm64_v8.0
    • partial build                                  match=target=linux_arm64_v8.0
    • building                                       paths=cmd/uncloudd binaries=uncloudd target=linux_arm64_v8.0
    • building                                       paths=cmd/uncloud binaries=uc target=linux_arm64_v8.0
  • size reports
    • 49.5MiB                                        path=dist/uncloudd_linux_arm64_v8.0/uncloudd
    • 93.25MiB                                       path=dist/uncloud_linux_arm64_v8.0/uc
  • writing artifacts metadata
  • you are using deprecated options, check the output above for details
  • build succeeded after 2s
  • thanks for using GoReleaser!
```