### PR TITLE
fix: reject extra args in context commands

### DIFF
--- a/cmd/uncloud/context/args_test.go
+++ b/cmd/uncloud/context/args_test.go
@@ -1,0 +1,103 @@
+package context
+
+import (
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCommandArgsValidation(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		newCmd  func() *cobra.Command
+		args    []string
+		wantErr bool
+	}{
+		{
+			name:    "root accepts no args",
+			newCmd:  NewRootCommand,
+			args:    nil,
+			wantErr: false,
+		},
+		{
+			name:    "root rejects extra args",
+			newCmd:  NewRootCommand,
+			args:    []string{"extra"},
+			wantErr: true,
+		},
+		{
+			name:    "list accepts no args",
+			newCmd:  NewListCommand,
+			args:    nil,
+			wantErr: false,
+		},
+		{
+			name:    "list rejects extra args",
+			newCmd:  NewListCommand,
+			args:    []string{"extra"},
+			wantErr: true,
+		},
+		{
+			name:    "show accepts no args",
+			newCmd:  NewShowCommand,
+			args:    nil,
+			wantErr: false,
+		},
+		{
+			name:    "show rejects extra args",
+			newCmd:  NewShowCommand,
+			args:    []string{"extra"},
+			wantErr: true,
+		},
+		{
+			name:    "connection accepts no args",
+			newCmd:  NewConnectionCommand,
+			args:    nil,
+			wantErr: false,
+		},
+		{
+			name:    "connection rejects extra args",
+			newCmd:  NewConnectionCommand,
+			args:    []string{"extra"},
+			wantErr: true,
+		},
+		{
+			name:    "use accepts no args",
+			newCmd:  NewUseCommand,
+			args:    nil,
+			wantErr: false,
+		},
+		{
+			name:    "use accepts one arg",
+			newCmd:  NewUseCommand,
+			args:    []string{"prod"},
+			wantErr: false,
+		},
+		{
+			name:    "use rejects extra args",
+			newCmd:  NewUseCommand,
+			args:    []string{"prod", "extra"},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			cmd := tt.newCmd()
+			require.NotNil(t, cmd.Args)
+
+			err := cmd.Args(cmd, tt.args)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+		})
+	}
+}

--- a/cmd/uncloud/context/connection.go
+++ b/cmd/uncloud/context/connection.go
@@ -14,6 +14,7 @@ func NewConnectionCommand() *cobra.Command {
 		Use:     "connection",
 		Aliases: []string{"conn"},
 		Short:   "Choose a new default connection for the current context.",
+		Args:    cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			uncli := cmd.Context().Value("cli").(*cli.CLI)
 			return selectConnection(uncli)

--- a/cmd/uncloud/context/ls.go
+++ b/cmd/uncloud/context/ls.go
@@ -15,6 +15,7 @@ func NewListCommand() *cobra.Command {
 		Use:     "ls",
 		Aliases: []string{"list"},
 		Short:   "List available cluster contexts.",
+		Args:    cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			uncli := cmd.Context().Value("cli").(*cli.CLI)
 			return list(uncli)

--- a/cmd/uncloud/context/root.go
+++ b/cmd/uncloud/context/root.go
@@ -10,6 +10,7 @@ func NewRootCommand() *cobra.Command {
 		Use:     "ctx",
 		Aliases: []string{"context"},
 		Short:   "Switch between different cluster contexts. Contains subcommands to manage contexts.",
+		Args:    cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			uncli := cmd.Context().Value("cli").(*cli.CLI)
 			return selectContext(uncli)

--- a/cmd/uncloud/context/show.go
+++ b/cmd/uncloud/context/show.go
@@ -11,6 +11,7 @@ func NewShowCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "show",
 		Short: "Show current cluster context.",
+		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			uncli := cmd.Context().Value("cli").(*cli.CLI)
 			return show(uncli)

--- a/cmd/uncloud/context/use.go
+++ b/cmd/uncloud/context/use.go
@@ -17,6 +17,7 @@ func NewUseCommand() *cobra.Command {
 		Short: "Switch to a different cluster context.",
 		Long: "Switch to a different cluster context. If no context is provided, " +
 			"a list of available contexts will be displayed for selection.",
+		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			uncli := cmd.Context().Value("cli").(*cli.CLI)
 


### PR DESCRIPTION
## What
`uc context` commands were a bit too chill with extra args.

On `main`, these bad calls still run:
```bash
uc context show extra
uc context ls extra
uc context use prod extra
```

`show` and `ls` ignore the extra arg and exit 0.
`use` drops into the interactive selector. Kinda weird.

This adds Cobra arg validation across the context command family, plus a small table test.

## Repro
Use any config with at least one context, then run the commands above.

Expected:
all of them fail fast with an arg error.

## Checks
```bash
go test ./cmd/uncloud/context
go test ./cmd/uncloud/... ./internal/cli/... ./pkg/api/... ./pkg/client/...
```
