### PR TITLE
Fix completion with direct connections

### DIFF
--- a/cmd/uncloud/main.go
+++ b/cmd/uncloud/main.go
@@ -24,6 +24,7 @@ import (
 	"github.com/psviderski/uncloud/internal/machine"
 	"github.com/psviderski/uncloud/internal/version"
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 )
 
 type globalOptions struct {
@@ -43,6 +44,8 @@ func main() {
 		SilenceUsage:  true,
 		SilenceErrors: true,
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+			// Cobra initializers run before completion and may hit an init error
+			// before PersistentPreRunE gets a chance to run.
 			if initErr != nil {
 				return initErr
 			}
@@ -124,6 +127,9 @@ func initCLI(cmd *cobra.Command, opts globalOptions) error {
 	cli.BindEnvToFlag(cmd, "connect", "UNCLOUD_CONNECT")
 	cli.BindEnvToFlag(cmd, "context", "UNCLOUD_CONTEXT")
 	cli.BindEnvToFlag(cmd, "uncloud-config", "UNCLOUD_CONFIG")
+	if opts.connect == "" {
+		opts.connect = connectFlagFromCompletionArgs(os.Args[1:])
+	}
 
 	var conn *config.MachineConnection
 	if opts.connect != "" {
@@ -175,8 +181,23 @@ func initCLI(cmd *cobra.Command, opts globalOptions) error {
 	return nil
 }
 
+func connectFlagFromCompletionArgs(args []string) string {
+	var connect string
+	flags := pflag.NewFlagSet("completion", pflag.ContinueOnError)
+	flags.ParseErrorsAllowlist.UnknownFlags = true
+	flags.StringVar(&connect, "connect", "", "")
+	_ = flags.Parse(args)
+	return connect
+}
+
 func setCLIContext(cmd *cobra.Command, uncli *cli.CLI) {
-	cmd.SetContext(context.WithValue(cmd.Context(), "cli", uncli))
+	// Completion callbacks read from the leaf command context, not always from
+	// the root command where initCLI runs.
+	ctx := cmd.Context()
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	cmd.SetContext(context.WithValue(ctx, "cli", uncli))
 	for _, child := range cmd.Commands() {
 		setCLIContext(child, uncli)
 	}

--- a/cmd/uncloud/main.go
+++ b/cmd/uncloud/main.go
@@ -36,64 +36,17 @@ func main() {
 	log.InitLoggerFromEnv()
 
 	opts := globalOptions{}
+	var initErr error
 	cmd := &cobra.Command{
 		Use:           "uc",
 		Short:         "A CLI tool for managing Uncloud resources such as machines, services, and volumes.",
 		SilenceUsage:  true,
 		SilenceErrors: true,
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
-			cli.BindEnvToFlag(cmd, "connect", "UNCLOUD_CONNECT")
-			cli.BindEnvToFlag(cmd, "context", "UNCLOUD_CONTEXT")
-			cli.BindEnvToFlag(cmd, "uncloud-config", "UNCLOUD_CONFIG")
-
-			var conn *config.MachineConnection
-			if opts.connect != "" {
-				if after, ok := strings.CutPrefix(opts.connect, "tcp://"); ok {
-					addrPort, err := netip.ParseAddrPort(after)
-					if err != nil {
-						return fmt.Errorf("parse TCP address: %w", err)
-					}
-					conn = &config.MachineConnection{
-						TCP: &addrPort,
-					}
-				} else if after, ok := strings.CutPrefix(opts.connect, "ssh+go://"); ok {
-					conn = &config.MachineConnection{
-						SSHGo: config.SSHDestination(after),
-					}
-				} else if after, ok := strings.CutPrefix(opts.connect, "ssh+cli://"); ok {
-					// Backward-compatible alias for ssh://.
-					conn = &config.MachineConnection{
-						SSH: config.SSHDestination(after),
-					}
-				} else if strings.HasPrefix(opts.connect, "unix://") {
-					conn = &config.MachineConnection{
-						Unix: opts.connect[len("unix://"):],
-					}
-				} else {
-					// Default: system ssh CLI command (no prefix or ssh:// prefix).
-					dest := strings.TrimPrefix(opts.connect, "ssh://")
-					conn = &config.MachineConnection{
-						SSH: config.SSHDestination(dest),
-					}
-				}
+			if initErr != nil {
+				return initErr
 			}
-
-			configPath := fs.ExpandHomeDir(opts.configPath)
-
-			if opts.connect == "" {
-				if !fs.Exists(configPath) && fs.Exists(machine.DefaultUncloudSockPath) {
-					conn = &config.MachineConnection{
-						Unix: machine.DefaultUncloudSockPath,
-					}
-				}
-			}
-
-			uncli, err := cli.New(configPath, conn, opts.context)
-			if err != nil {
-				return fmt.Errorf("initialise CLI: %w", err)
-			}
-			cmd.SetContext(context.WithValue(cmd.Context(), "cli", uncli))
-			return nil
+			return initCLI(cmd, opts)
 		},
 	}
 
@@ -105,6 +58,10 @@ func main() {
 	_ = cmd.MarkPersistentFlagFilename("uncloud-config", "yaml", "yml")
 	cmd.PersistentFlags().StringVarP(&opts.context, "context", "c", "",
 		"Name of the cluster context to use (default is the current context). [$UNCLOUD_CONTEXT]")
+
+	cobra.OnInitialize(func() {
+		initErr = initCLI(cmd, opts)
+	})
 
 	// Set custom help function to show links to docs and Discord only for the root 'uc' command.
 	defaultHelpFunc := cmd.HelpFunc()
@@ -156,5 +113,71 @@ func main() {
 			os.Exit(1)
 		}
 		cobra.CheckErr(err)
+	}
+}
+
+func initCLI(cmd *cobra.Command, opts globalOptions) error {
+	if cmd.Context().Value("cli") != nil {
+		return nil
+	}
+
+	cli.BindEnvToFlag(cmd, "connect", "UNCLOUD_CONNECT")
+	cli.BindEnvToFlag(cmd, "context", "UNCLOUD_CONTEXT")
+	cli.BindEnvToFlag(cmd, "uncloud-config", "UNCLOUD_CONFIG")
+
+	var conn *config.MachineConnection
+	if opts.connect != "" {
+		if after, ok := strings.CutPrefix(opts.connect, "tcp://"); ok {
+			addrPort, err := netip.ParseAddrPort(after)
+			if err != nil {
+				return fmt.Errorf("parse TCP address: %w", err)
+			}
+			conn = &config.MachineConnection{
+				TCP: &addrPort,
+			}
+		} else if after, ok := strings.CutPrefix(opts.connect, "ssh+go://"); ok {
+			conn = &config.MachineConnection{
+				SSHGo: config.SSHDestination(after),
+			}
+		} else if after, ok := strings.CutPrefix(opts.connect, "ssh+cli://"); ok {
+			// Backward-compatible alias for ssh://.
+			conn = &config.MachineConnection{
+				SSH: config.SSHDestination(after),
+			}
+		} else if strings.HasPrefix(opts.connect, "unix://") {
+			conn = &config.MachineConnection{
+				Unix: opts.connect[len("unix://"):],
+			}
+		} else {
+			// Default: system ssh CLI command (no prefix or ssh:// prefix).
+			dest := strings.TrimPrefix(opts.connect, "ssh://")
+			conn = &config.MachineConnection{
+				SSH: config.SSHDestination(dest),
+			}
+		}
+	}
+
+	configPath := fs.ExpandHomeDir(opts.configPath)
+
+	if opts.connect == "" {
+		if !fs.Exists(configPath) && fs.Exists(machine.DefaultUncloudSockPath) {
+			conn = &config.MachineConnection{
+				Unix: machine.DefaultUncloudSockPath,
+			}
+		}
+	}
+
+	uncli, err := cli.New(configPath, conn, opts.context)
+	if err != nil {
+		return fmt.Errorf("initialise CLI: %w", err)
+	}
+	setCLIContext(cmd.Root(), uncli)
+	return nil
+}
+
+func setCLIContext(cmd *cobra.Command, uncli *cli.CLI) {
+	cmd.SetContext(context.WithValue(cmd.Context(), "cli", uncli))
+	for _, child := range cmd.Commands() {
+		setCLIContext(child, uncli)
 	}
 }

--- a/internal/cli/completion/machine.go
+++ b/internal/cli/completion/machine.go
@@ -10,7 +10,7 @@ import (
 )
 
 func Machines(ctx context.Context, uncli *cli.CLI, args []string, toComplete string) ([]cobra.Completion, cobra.ShellCompDirective) {
-	client, err := uncli.ConnectCluster(ctx)
+	client, err := uncli.ConnectClusterWithOptions(ctx, cli.ConnectOptions{})
 	if err != nil {
 		return nil, cobra.ShellCompDirectiveError
 	}

--- a/internal/cli/completion/service.go
+++ b/internal/cli/completion/service.go
@@ -11,7 +11,7 @@ import (
 )
 
 func Services(ctx context.Context, uncli *cli.CLI, args []string, toComplete string) ([]cobra.Completion, cobra.ShellCompDirective) {
-	client, err := uncli.ConnectCluster(ctx)
+	client, err := uncli.ConnectClusterWithOptions(ctx, cli.ConnectOptions{})
 	if err != nil {
 		return nil, cobra.ShellCompDirectiveError
 	}

--- a/internal/cli/completion/volume.go
+++ b/internal/cli/completion/volume.go
@@ -11,7 +11,7 @@ import (
 )
 
 func Volumes(ctx context.Context, uncli *cli.CLI, args []string, toComplete string) ([]cobra.Completion, cobra.ShellCompDirective) {
-	client, err := uncli.ConnectCluster(ctx)
+	client, err := uncli.ConnectClusterWithOptions(ctx, cli.ConnectOptions{})
 	if err != nil {
 		return nil, cobra.ShellCompDirectiveError
 	}


### PR DESCRIPTION
fixes #377 

## Summary

- Initialize the CLI before Cobra completion runs.
- Read global flags during completion so `--connect` works without a config file.
- Disable connection progress output during completion.

## Testing

- `GOCACHE=/tmp/go-build GOMODCACHE=/tmp/go-mod go test ./cmd/uncloud ./internal/cli/completion`
- `GOCACHE=/tmp/go-build GOMODCACHE=/tmp/go-mod go build -o /tmp/uc ./cmd/uncloud`
- `HOME=/tmp/uc-nohome /tmp/uc __complete --connect tcp://bad inspect ''`

Full `go test -p 1 ./...` passed for non-e2e packages. `test/e2e` failed with existing Docker cluster runtime errors about invalid IPv6 addresses.