### PR TITLE
uc: add caddy logs

### DIFF
--- a/cmd/uncloud/caddy/logs.go
+++ b/cmd/uncloud/caddy/logs.go
@@ -1,0 +1,30 @@
+package caddy
+
+import (
+	"github.com/psviderski/uncloud/cmd/uncloud/service"
+	"github.com/psviderski/uncloud/internal/cli"
+	"github.com/psviderski/uncloud/internal/cli/logs"
+	"github.com/spf13/cobra"
+)
+
+func NewLogsCommand() *cobra.Command {
+	var options logs.Options
+
+	cmd := &cobra.Command{
+		Use:     "logs",
+		Aliases: []string{"log"},
+		Short:   "View caddy logs.",
+		Long: `View caddy logs.
+
+This call "uc logs caddy", see "uc logs" for the documention.
+`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			args = append([]string{"caddy"}, args...)
+			uncli := cmd.Context().Value("cli").(*cli.CLI)
+			return service.RunLogs(cmd.Context(), uncli, args, options)
+		},
+	}
+	cmd.Flags().AddFlagSet(logs.Flags(&options))
+	return cmd
+
+}

--- a/cmd/uncloud/caddy/logs.go
+++ b/cmd/uncloud/caddy/logs.go
@@ -16,7 +16,7 @@ func NewLogsCommand() *cobra.Command {
 		Short:   "View caddy logs.",
 		Long: `View caddy logs.
 
-This call "uc logs caddy", see "uc logs" for the documention.
+This calls "uc logs caddy", see "uc logs" for the documention.
 `,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			args = append([]string{"caddy"}, args...)

--- a/cmd/uncloud/caddy/logs.go
+++ b/cmd/uncloud/caddy/logs.go
@@ -26,5 +26,4 @@ This calls "uc logs caddy", see "uc logs" for the documention.
 	}
 	cmd.Flags().AddFlagSet(logs.Flags(&options))
 	return cmd
-
 }

--- a/cmd/uncloud/caddy/root.go
+++ b/cmd/uncloud/caddy/root.go
@@ -12,6 +12,7 @@ func NewRootCommand() *cobra.Command {
 	cmd.AddCommand(
 		NewConfigCommand(),
 		NewDeployCommand(),
+		NewLogsCommand(),
 	)
 	return cmd
 }

--- a/cmd/uncloud/service/logs.go
+++ b/cmd/uncloud/service/logs.go
@@ -59,7 +59,7 @@ If no services are specified, streams logs from all services defined in the Comp
   uc logs -m machine1,machine2 web api`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			uncli := cmd.Context().Value("cli").(*cli.CLI)
-			return runLogs(cmd.Context(), uncli, args, options)
+			return RunLogs(cmd.Context(), uncli, args, options)
 		},
 		GroupID: groupID,
 		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]cobra.Completion, cobra.ShellCompDirective) {
@@ -77,7 +77,7 @@ If no services are specified, streams logs from all services defined in the Comp
 	return cmd
 }
 
-func runLogs(ctx context.Context, uncli *cli.CLI, args []string, opts logs.Options) error {
+func RunLogs(ctx context.Context, uncli *cli.CLI, args []string, opts logs.Options) error {
 	serviceArgs, err := logs.ParseServiceArgs(args)
 	if err != nil {
 		return err

--- a/website/docs/9-cli-reference/uc_caddy.md
+++ b/website/docs/9-cli-reference/uc_caddy.md
@@ -22,4 +22,5 @@ Manage Caddy reverse proxy service.
 * [uc](uc.md)	 - A CLI tool for managing Uncloud resources such as machines, services, and volumes.
 * [uc caddy config](uc_caddy_config.md)	 - Show the current Caddy configuration (Caddyfile).
 * [uc caddy deploy](uc_caddy_deploy.md)	 - Deploy or upgrade Caddy reverse proxy across all machines in the cluster.
+* [uc caddy logs](uc_caddy_logs.md)	 - View caddy logs.
 

--- a/website/docs/9-cli-reference/uc_caddy_logs.md
+++ b/website/docs/9-cli-reference/uc_caddy_logs.md
@@ -1,0 +1,48 @@
+# uc caddy logs
+
+View caddy logs.
+
+## Synopsis
+
+View caddy logs.
+
+This calls "uc logs caddy", see "uc logs" for the documention.
+
+
+```
+uc caddy logs [flags]
+```
+
+## Options
+
+```
+  -f, --follow            Continually stream new logs.
+  -h, --help              help for logs
+  -m, --machine strings   Filter logs by machine name or ID. Can be specified multiple times or as a comma-separated list.
+      --since string      Show logs generated on or after the given timestamp. Accepts relative duration, RFC 3339 date, or Unix timestamp.
+                          Examples:
+                            --since 2m30s                      Relative duration (2 minutes 30 seconds ago)
+                            --since 1h                         Relative duration (1 hour ago)
+                            --since 2025-11-24                 RFC 3339 date only (midnight using local timezone)
+                            --since 2024-05-14T22:50:00        RFC 3339 date/time using local timezone
+                            --since 2024-01-31T10:30:00Z       RFC 3339 date/time in UTC
+                            --since 1763953966                 Unix timestamp (seconds since January 1, 1970)
+  -n, --tail string       Show the most recent logs and limit the number of lines shown per replica. Use 'all' to show all logs. (default "100")
+      --until string      Show logs generated before the given timestamp. Accepts relative duration, RFC 3339 date, or Unix timestamp.
+                          See --since for examples.
+      --utc               Print timestamps in UTC instead of local timezone.
+```
+
+## Options inherited from parent commands
+
+```
+      --connect string          Connect to a remote cluster machine without using the Uncloud configuration file. [$UNCLOUD_CONNECT]
+                                Format: [ssh://]user@host[:port], ssh+go://user@host[:port], tcp://host:port, or unix:///path/to/uncloud.sock
+  -c, --context string          Name of the cluster context to use (default is the current context). [$UNCLOUD_CONTEXT]
+      --uncloud-config string   Path to the Uncloud configuration file. [$UNCLOUD_CONFIG] (default "~/.config/uncloud/config.yaml")
+```
+
+## See also
+
+* [uc caddy](uc_caddy.md)	 - Manage Caddy reverse proxy service.
+


### PR DESCRIPTION
When dealing _a lot_ with caddy, i.e caddy config, caddy deploy, doing caddy logs comes very naturally, but that is uc logs caddy.

Add a logs subcommand that just calls "uc log caddy" from "uc caddy logs".

Fixes: #374