### PR TITLE
fix: corrosion logs are now service logs

### DIFF
--- a/cmd/uncloud/machine/logs.go
+++ b/cmd/uncloud/machine/logs.go
@@ -104,11 +104,21 @@ func runLogs(ctx context.Context, uncli *cli.CLI, units []string, opts logs.Opti
 	// Collect one log stream per unit. MachineLogs merges across machines internally.
 	unitStreams := make([]<-chan api.ServiceLogEntry, 0, len(units))
 	for _, unit := range units {
-		ch, err := c.MachineLogs(ctx, unit, logsOpts)
-		if err != nil {
-			return fmt.Errorf("stream logs for systemd service '%s': %w", unit, err)
+		switch unit {
+		case journal.UnitCorrosion:
+			// corrosion was moved to a container, but it is still a machine service, get the logs from docker
+			_, ch, err := c.ServiceLogs(ctx, unit, logsOpts)
+			if err != nil {
+				return fmt.Errorf("stream logs for system container '%s': %w", unit, err)
+			}
+			unitStreams = append(unitStreams, ch)
+		default:
+			ch, err := c.MachineLogs(ctx, unit, logsOpts)
+			if err != nil {
+				return fmt.Errorf("stream logs for systemd service '%s': %w", unit, err)
+			}
+			unitStreams = append(unitStreams, ch)
 		}
-		unitStreams = append(unitStreams, ch)
 	}
 
 	var stream <-chan api.ServiceLogEntry

--- a/internal/journal/journal.go
+++ b/internal/journal/journal.go
@@ -13,7 +13,7 @@ import (
 const (
 	UnitUncloud   = "uncloud"
 	UnitDocker    = "docker"
-	UnitCorrosion = "uncloud-corrosion"
+	UnitCorrosion = "uncloud-corrosion" // Not a unit anymore, but a container.
 )
 
 func ValidUnit(unit string) bool {


### PR DESCRIPTION
Get the system logs for corrosion from docker now that corrosion is a system image instead of the systemd unit.

(Nice to see that the logging refactoring makes this super easy)