### PR TITLE
feat: add secrets

### DIFF
--- a/internal/machine/docker/server.go
+++ b/internal/machine/docker/server.go
@@ -716,6 +716,13 @@ func (s *Server) CreateServiceContainer(
 		return nil, status.Errorf(codes.Internal, "inject configs: %v", err)
 	}
 
+	// Inject secrets into the created container
+	if err = s.injectSecrets(ctx, resp.ID, spec.Secrets, spec.Container.SecretMounts); err != nil {
+		// Remove the container if secret injection fails
+		_ = s.client.ContainerRemove(ctx, resp.ID, container.RemoveOptions{RemoveVolumes: true})
+		return nil, status.Errorf(codes.Internal, "inject secrets: %v", err)
+	}
+
 	respBytes, err := json.Marshal(resp)
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "marshal response: %v", err)
@@ -790,6 +797,66 @@ func ToDockerMounts(volumes []api.VolumeSpec, mounts []api.VolumeMount) ([]mount
 	}
 
 	return dockerMounts, nil
+}
+
+// injectSecrets writes secret content directly into the container.
+// It processes SecretSpecs and SecretMounts to mount secret content into the container filesystem.
+func (s *Server) injectSecrets(ctx context.Context, containerID string, secrets []api.SecretSpec, mounts []api.SecretMount) error {
+	if len(secrets) == 0 || len(mounts) == 0 {
+		return nil
+	}
+
+	if err := api.ValidateSecretsAndMounts(secrets, mounts); err != nil {
+		return fmt.Errorf("validate secrets and mounts: %w", err)
+	}
+
+	secretMap := make(map[string]api.SecretSpec)
+	for _, secret := range secrets {
+		secretMap[secret.Name] = secret
+	}
+
+	for _, m := range mounts {
+		secret, exists := secretMap[m.ConfigName]
+		if !exists {
+			return fmt.Errorf("secret mount references a secret that doesn't exist: '%s'", m.ConfigName)
+		}
+
+		targetPath := filepath.Join("/run/secrets", m.ConfigName)
+
+		fileMode := os.FileMode(0o400)
+		if m.Mode != nil {
+			fileMode = *m.Mode
+		}
+
+		uid, err := m.GetNumericUid()
+		if err != nil {
+			return fmt.Errorf("invalid Uid: %w", err)
+		}
+
+		gid, err := m.GetNumericGid()
+		if err != nil {
+			return fmt.Errorf("invalid Gid: %w", err)
+		}
+
+		if err := s.copyContentToContainer(ctx, containerID, secret.Content, targetPath, uid, gid, fileMode); err != nil {
+			return fmt.Errorf("copy secret file '%s' to container: %w", secret.Name, err)
+		}
+
+		// if a container path was specific symlink that path to the /run/secrets secret. This way the secret
+		// stays on a tmpfs and isn't written to some storage.
+		if m.ContainerPath != "" {
+			if err := os.Symlink(targetPath, m.ContainerPath); err != nil {
+				return fmt.Errorf("symlinking secret from '%s' to '%s': %w", targetPath, m.ContainerPath, err)
+			}
+		}
+
+		slog.Debug("Injected secret into container",
+			"secret", secret.Name,
+			"container", containerID[:12],
+			"target", targetPath)
+	}
+
+	return nil
 }
 
 // injectConfigs writes config content directly into the container.

--- a/internal/machine/docker/server.go
+++ b/internal/machine/docker/server.go
@@ -846,7 +846,7 @@ func (s *Server) injectSecrets(ctx context.Context, containerID string, secrets 
 		// stays on a tmpfs and isn't written to some storage.
 		if m.ContainerPath != "" {
 			if err := os.Symlink(targetPath, m.ContainerPath); err != nil {
-				return fmt.Errorf("symlinking secret from '%s' to '%s': %w", targetPath, m.ContainerPath, err)
+				return fmt.Errorf("symlinking secret from '%s' to '%s': %w", m.ContainerPath, targetPath, err)
 			}
 		}
 

--- a/internal/machine/store/container.go
+++ b/internal/machine/store/container.go
@@ -3,6 +3,7 @@ package store
 import (
 	"cmp"
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"log/slog"
@@ -92,6 +93,17 @@ func normaliseContainerForStore(ctr *api.ServiceContainer) {
 	// Remove the environment variables to avoid leaking secrets.
 	ctr.Config.Env = nil
 	ctr.ServiceSpec.Container.Env = nil
+
+	// Base64 encode secrets, we should encrypt them, but where does that key live, so it doesn't look. For
+	// now do a fake base64 "encryption" to at least have some code that can later be updated to do proper
+	// encryption. TODO: encrypt properly.
+	for i := range ctr.ServiceSpec.Secrets {
+		content := ctr.ServiceSpec.Secrets[i].Content
+		b64 := make([]byte, base64.StdEncoding.EncodedLen(len(content)))
+		base64.StdEncoding.Encode(b64, content)
+
+		ctr.ServiceSpec.Secrets[i].Content = b64
+	}
 
 	// Docker returns Mounts in a non-deterministic order so sort them.
 	slices.SortFunc(ctr.Mounts, func(a, b container.MountPoint) int {

--- a/pkg/api/config.go
+++ b/pkg/api/config.go
@@ -64,7 +64,7 @@ func (c *ConfigMount) GetNumericUid() (*uint64, error) {
 		return nil, fmt.Errorf("invalid Uid '%s': %w", c.Uid, err)
 	}
 	if int(uid) < 0 {
-		return nil, fmt.Errorf("invalid Uid '%s': value too high", c.Uid)
+		return nil, fmt.Errorf("invalid Uid '%s': value too low", c.Uid)
 	}
 	return &uid, nil
 }
@@ -78,7 +78,7 @@ func (c *ConfigMount) GetNumericGid() (*uint64, error) {
 		return nil, fmt.Errorf("invalid Gid '%s': %w", c.Gid, err)
 	}
 	if int(gid) < 0 {
-		return nil, fmt.Errorf("invalid Gid '%s': value too high", c.Gid)
+		return nil, fmt.Errorf("invalid Gid '%s': value too low", c.Gid)
 	}
 	return &gid, nil
 }
@@ -166,6 +166,13 @@ func (c *ConfigMount) Clone() ConfigMount {
 func sortConfigMounts(mounts []ConfigMount) {
 	sort.Slice(mounts, func(i, j int) bool {
 		return mounts[i].Compare(&mounts[j]) < 0
+	})
+}
+
+// sortSecretMounts sorts a slice of SecretMount instances.
+func sortSecretMounts(mounts []SecretMount) {
+	sort.Slice(mounts, func(i, j int) bool {
+		return mounts[i].Compare(&mounts[j].ConfigMount) < 0
 	})
 }
 

--- a/pkg/api/config.go
+++ b/pkg/api/config.go
@@ -64,7 +64,7 @@ func (c *ConfigMount) GetNumericUid() (*uint64, error) {
 		return nil, fmt.Errorf("invalid Uid '%s': %w", c.Uid, err)
 	}
 	if int(uid) < 0 {
-		return nil, fmt.Errorf("invalid Uid '%s': value too low", c.Uid)
+		return nil, fmt.Errorf("invalid Uid '%s': value too high", c.Uid)
 	}
 	return &uid, nil
 }
@@ -78,7 +78,7 @@ func (c *ConfigMount) GetNumericGid() (*uint64, error) {
 		return nil, fmt.Errorf("invalid Gid '%s': %w", c.Gid, err)
 	}
 	if int(gid) < 0 {
-		return nil, fmt.Errorf("invalid Gid '%s': value too low", c.Gid)
+		return nil, fmt.Errorf("invalid Gid '%s': value too high", c.Gid)
 	}
 	return &gid, nil
 }
@@ -166,13 +166,6 @@ func (c *ConfigMount) Clone() ConfigMount {
 func sortConfigMounts(mounts []ConfigMount) {
 	sort.Slice(mounts, func(i, j int) bool {
 		return mounts[i].Compare(&mounts[j]) < 0
-	})
-}
-
-// sortSecretMounts sorts a slice of SecretMount instances.
-func sortSecretMounts(mounts []SecretMount) {
-	sort.Slice(mounts, func(i, j int) bool {
-		return mounts[i].Compare(&mounts[j].ConfigMount) < 0
 	})
 }
 

--- a/pkg/api/secret.go
+++ b/pkg/api/secret.go
@@ -6,7 +6,7 @@ import (
 	"sort"
 )
 
-// SecretSpec defines a secret object that can be mounted into containers
+// SecretSpec defines a secret object that can be mounted into containers.
 type SecretSpec struct {
 	ConfigSpec
 }
@@ -46,7 +46,8 @@ func sortSecretMounts(mounts []SecretMount) {
 	})
 }
 
-// ValidateSecretsAndMounts takes secret specs and secret mounts and validates that all mounts refer to existing specs
+// ValidateSecretsAndMounts takes secret specs and secret mounts and validates that all mounts refer to
+// existing specs.
 func ValidateSecretsAndMounts(secrets []SecretSpec, mounts []SecretMount) error {
 	secretMap := make(map[string]struct{})
 	for _, secret := range secrets {

--- a/pkg/api/secret.go
+++ b/pkg/api/secret.go
@@ -3,6 +3,7 @@ package api
 import (
 	"fmt"
 	"path/filepath"
+	"sort"
 )
 
 // SecretSpec defines a secret object that can be mounted into containers
@@ -36,6 +37,13 @@ func (s *SecretMount) Validate() error {
 		return fmt.Errorf("secret container path must be absolute")
 	}
 	return nil
+}
+
+// sortSecretMounts sorts a slice of SecretMount instances.
+func sortSecretMounts(mounts []SecretMount) {
+	sort.Slice(mounts, func(i, j int) bool {
+		return mounts[i].Compare(&mounts[j].ConfigMount) < 0
+	})
 }
 
 // ValidateSecretsAndMounts takes secret specs and secret mounts and validates that all mounts refer to existing specs

--- a/pkg/api/secret.go
+++ b/pkg/api/secret.go
@@ -1,0 +1,65 @@
+package api
+
+import (
+	"fmt"
+	"path/filepath"
+)
+
+// SecretSpec defines a secret object that can be mounted into containers
+type SecretSpec struct {
+	ConfigSpec
+}
+
+func (s *SecretSpec) Validate() error {
+	if s.Name == "" {
+		return fmt.Errorf("secret name is required")
+	}
+	return nil
+}
+
+// SecretMount defines how a secret is mounted into a container.
+type SecretMount struct {
+	ConfigMount
+}
+
+func (s *SecretMount) Validate() error {
+	if s.ConfigName == "" {
+		return fmt.Errorf("secret mount source is required")
+	}
+	if _, err := s.GetNumericUid(); err != nil {
+		return err
+	}
+	if _, err := s.GetNumericGid(); err != nil {
+		return err
+	}
+	if s.ContainerPath != "" && !filepath.IsAbs(s.ContainerPath) {
+		return fmt.Errorf("secret container path must be absolute")
+	}
+	return nil
+}
+
+// ValidateSecretsAndMounts takes secret specs and secret mounts and validates that all mounts refer to existing specs
+func ValidateSecretsAndMounts(secrets []SecretSpec, mounts []SecretMount) error {
+	secretMap := make(map[string]struct{})
+	for _, secret := range secrets {
+		if err := secret.Validate(); err != nil {
+			return fmt.Errorf("invalid secret: %w", err)
+		}
+		if _, ok := secretMap[secret.Name]; ok {
+			return fmt.Errorf("duplicate secret name: '%s'", secret.Name)
+		}
+
+		secretMap[secret.Name] = struct{}{}
+	}
+
+	for _, mount := range mounts {
+		if err := mount.Validate(); err != nil {
+			return fmt.Errorf("invalid secret mount: %w", err)
+		}
+		if _, exists := secretMap[mount.ConfigName]; !exists {
+			return fmt.Errorf("secret mount source '%s' does not refer to any defined secret", mount.ConfigName)
+		}
+	}
+
+	return nil
+}

--- a/pkg/api/service.go
+++ b/pkg/api/service.go
@@ -57,6 +57,8 @@ type ServiceSpec struct {
 	Caddy *CaddySpec `json:",omitempty"`
 	// Configs is a list of configuration objects that can be mounted into the container.
 	Configs []ConfigSpec
+	// Secrets is list of secret objects that can be mounted into the container.
+	Secrets []SecretSpec
 	// Container defines the desired state of each container in the service.
 	Container ContainerSpec
 	// Mode is the replication mode of the service. Default is ServiceModeReplicated if empty.
@@ -102,6 +104,15 @@ func (s *ServiceSpec) Config(name string) (ConfigSpec, bool) {
 		}
 	}
 	return ConfigSpec{}, false
+}
+
+func (s *ServiceSpec) Secret(name string) (SecretSpec, bool) {
+	for _, secret := range s.Secrets {
+		if secret.Name == name {
+			return secret, true
+		}
+	}
+	return SecretSpec{}, false
 }
 
 // MountedDockerVolumes returns the list of volumes of VolumeTypeVolume type that are mounted into the container.
@@ -208,6 +219,11 @@ func (s *ServiceSpec) Validate() error {
 		return fmt.Errorf("validate service configs and mounts: %w", err)
 	}
 
+	// Validate secrets
+	if err := ValidateSecretsAndMounts(s.Secrets, s.Container.SecretMounts); err != nil {
+		return fmt.Errorf("validate service secrets and mounts: %w", err)
+	}
+
 	if s.PreDeploy != nil {
 		if err := s.PreDeploy.Validate(); err != nil {
 			return err
@@ -237,6 +253,11 @@ func (s *ServiceSpec) Clone() ServiceSpec {
 		for i, v := range s.Volumes {
 			spec.Volumes[i] = v.Clone()
 		}
+	}
+
+	if s.Secrets != nil {
+		spec.Secrets = make([]SecretSpec, len(s.Secrets))
+		copy(spec.Secrets, s.Secrets)
 	}
 
 	return spec
@@ -285,6 +306,9 @@ type ContainerSpec struct {
 	// ConfigMounts specifies how configs are mounted into the container filesystem.
 	// Each mount references a config defined in ServiceSpec.Configs.
 	ConfigMounts []ConfigMount
+	// SecretMounts specifies how secrets are mounted into the container filesystem.
+	// Each mount references a secret defined in ServiceSpec.Secrets.
+	SecretMounts []SecretMount
 	// Volumes is list of data volumes to mount into the container.
 	// TODO(lhf): delete all usage, has been replaced with []VolumeMounts.
 	Volumes []string
@@ -335,6 +359,10 @@ func (s *ContainerSpec) Equals(spec ContainerSpec) bool {
 	// Config mounts
 	sortConfigMounts(orig.ConfigMounts)
 	sortConfigMounts(spec.ConfigMounts)
+
+	// Secrets
+	sortSecretMounts(orig.SecretMounts)
+	sortSecretMounts(spec.SecretMounts)
 
 	return cmp.Equal(orig, spec, cmpopts.EquateEmpty())
 }
@@ -387,6 +415,10 @@ func (s *ContainerSpec) Clone() ContainerSpec {
 		for i, cm := range s.ConfigMounts {
 			spec.ConfigMounts[i] = cm.Clone()
 		}
+	}
+	if s.SecretMounts != nil {
+		spec.SecretMounts = make([]SecretMount, len(s.SecretMounts))
+		copy(spec.SecretMounts, s.SecretMounts)
 	}
 	if s.Sysctls != nil {
 		spec.Sysctls = make(map[string]string, len(s.Sysctls))

--- a/pkg/client/compose/project_test.go
+++ b/pkg/client/compose/project_test.go
@@ -275,8 +275,8 @@ secrets:
   db_password:
     file: ./secret.txt
 `,
-			warnCount:    3,
-			warnContains: []string{"dns", "links", "secrets"},
+			warnCount:    2,
+			warnContains: []string{"dns", "links"},
 		},
 		{
 			name: "supported networks",

--- a/pkg/client/compose/secret.go
+++ b/pkg/client/compose/secret.go
@@ -1,0 +1,76 @@
+package compose
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/compose-spec/compose-go/v2/types"
+	"github.com/psviderski/uncloud/pkg/api"
+)
+
+func secretSpecsFromCompose(secrets types.Secrets, serviceSecrets []types.ServiceSecretConfig, workingDir string) ([]api.SecretSpec, []api.SecretMount, error) {
+	var secretSpecs []api.SecretSpec
+	var secretMounts []api.SecretMount
+
+	for _, serviceSecret := range serviceSecrets {
+		var spec api.SecretSpec
+
+		projectSecret, exists := secrets[serviceSecret.Source]
+		if !exists {
+			return nil, nil, fmt.Errorf("secret '%s' not found in project secrets", serviceSecret.Source)
+		}
+
+		if projectSecret.External {
+			return nil, nil, fmt.Errorf("external secrets are not supported: %s", serviceSecret.Source)
+		}
+
+		spec = api.SecretSpec{
+			ConfigSpec: api.ConfigSpec{
+				Name:    serviceSecret.Source,
+				Content: []byte(projectSecret.Content),
+			},
+		}
+
+		// If File is specified, read the file contents
+		if projectSecret.File != "" {
+			secretPath := projectSecret.File
+			// TODO: handle this in a separate function?
+			if !filepath.IsAbs(secretPath) {
+				secretPath = filepath.Join(workingDir, secretPath)
+			}
+
+			fileContent, err := os.ReadFile(secretPath)
+			if err != nil {
+				return nil, nil, fmt.Errorf("read secret from file '%s': %w", projectSecret.File, err)
+			}
+			spec.Content = fileContent
+		}
+
+		secretSpecs = append(secretSpecs, spec)
+
+		// Create secret mount
+		target := serviceSecret.Target
+		if target == "" {
+			target = "/run/secrets/" + serviceSecret.Source // Default mount path
+		}
+
+		mount := api.SecretMount{
+			ConfigMount: api.ConfigMount{
+				ConfigName:    spec.Name,
+				ContainerPath: target,
+				Uid:           serviceSecret.UID,
+				Gid:           serviceSecret.GID,
+			},
+		}
+
+		if serviceSecret.Mode != nil {
+			mode := os.FileMode(*serviceSecret.Mode)
+			mount.Mode = &mode
+		}
+
+		secretMounts = append(secretMounts, mount)
+	}
+
+	return secretSpecs, secretMounts, nil
+}

--- a/pkg/client/compose/secret.go
+++ b/pkg/client/compose/secret.go
@@ -32,10 +32,8 @@ func secretSpecsFromCompose(secrets types.Secrets, serviceSecrets []types.Servic
 			},
 		}
 
-		// If File is specified, read the file contents
 		if projectSecret.File != "" {
 			secretPath := projectSecret.File
-			// TODO: handle this in a separate function?
 			if !filepath.IsAbs(secretPath) {
 				secretPath = filepath.Join(workingDir, secretPath)
 			}
@@ -49,16 +47,10 @@ func secretSpecsFromCompose(secrets types.Secrets, serviceSecrets []types.Servic
 
 		secretSpecs = append(secretSpecs, spec)
 
-		// Create secret mount
-		target := serviceSecret.Target
-		if target == "" {
-			target = "/run/secrets/" + serviceSecret.Source // Default mount path
-		}
-
 		mount := api.SecretMount{
 			ConfigMount: api.ConfigMount{
 				ConfigName:    spec.Name,
-				ContainerPath: target,
+				ContainerPath: serviceSecret.Target,
 				Uid:           serviceSecret.UID,
 				Gid:           serviceSecret.GID,
 			},

--- a/pkg/client/compose/secret_test.go
+++ b/pkg/client/compose/secret_test.go
@@ -1,0 +1,114 @@
+package compose
+
+import (
+	"os"
+	"testing"
+
+	"github.com/compose-spec/compose-go/v2/types"
+	"github.com/psviderski/uncloud/pkg/api"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSecretSpecsFromCompose(t *testing.T) {
+	tests := []struct {
+		name           string
+		secrets        types.Secrets
+		serviceSecrets []types.ServiceSecretConfig
+		expectedSpecs  []api.SecretSpec
+		expectedMounts []api.SecretMount
+		expectError    bool
+	}{
+		{
+			name: "project-level secret with file",
+			secrets: types.Secrets{
+				"app-secret": types.SecretConfig{
+					File: "testdata/secret1.txt",
+				},
+			},
+			serviceSecrets: []types.ServiceSecretConfig{
+				{
+					Source: "app-secret",
+					Target: "/run/secrets/app-secret",
+					UID:    "1000",
+					GID:    "1000",
+				},
+			},
+			expectedSpecs: []api.SecretSpec{
+				{
+					Name:    "app-secret",
+					Content: []byte("test secret content\n"),
+				},
+			},
+			expectedMounts: []api.SecretMount{
+				{
+					SecretName:    "app-secret",
+					ContainerPath: "/run/secrets/app-secret",
+					Uid:           "1000",
+					Gid:           "1000",
+				},
+			},
+		},
+		{
+			name: "secret with mode",
+			secrets: types.Secrets{
+				"db-password": types.SecretConfig{
+					File: "./testdata/secret1.txt",
+				},
+			},
+			serviceSecrets: []types.ServiceSecretConfig{
+				{
+					Source: "db-password",
+					Target: "/run/secrets/db-password",
+					Mode:   func() *types.FileMode { m := types.FileMode(0o400); return &m }(),
+				},
+			},
+			expectedSpecs: []api.SecretSpec{
+				{
+					Name:    "db-password",
+					Content: []byte("test secret content\n"),
+				},
+			},
+			expectedMounts: []api.SecretMount{
+				{
+					SecretName:    "db-password",
+					ContainerPath: "/run/secrets/db-password",
+					Mode:          func() *os.FileMode { m := os.FileMode(0o400); return &m }(),
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			secretSpecs, secretMounts, err := secretSpecsFromCompose(tt.secrets, tt.serviceSecrets, ".")
+
+			if tt.expectError {
+				require.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.ElementsMatch(t, tt.expectedSpecs, secretSpecs)
+			assert.Equal(t, tt.expectedMounts, secretMounts)
+		})
+	}
+}
+
+func TestSecretSpecEquals(t *testing.T) {
+	secret1 := api.SecretSpec{
+		Name: "test-secret",
+	}
+
+	secret2 := api.SecretSpec{
+		Name: "test-secret",
+	}
+
+	secret3 := api.SecretSpec{
+		Name:    "test-secret",
+		Content: []byte("some content"),
+	}
+
+	assert.True(t, secret1.Equals(secret2))
+	assert.False(t, secret1.Equals(secret3))
+}

--- a/pkg/client/compose/secret_test.go
+++ b/pkg/client/compose/secret_test.go
@@ -36,16 +36,20 @@ func TestSecretSpecsFromCompose(t *testing.T) {
 			},
 			expectedSpecs: []api.SecretSpec{
 				{
-					Name:    "app-secret",
-					Content: []byte("test secret content\n"),
+					ConfigSpec: api.ConfigSpec{
+						Name:    "app-secret",
+						Content: []byte("test secret content\n"),
+					},
 				},
 			},
 			expectedMounts: []api.SecretMount{
 				{
-					SecretName:    "app-secret",
-					ContainerPath: "/run/secrets/app-secret",
-					Uid:           "1000",
-					Gid:           "1000",
+					ConfigMount: api.ConfigMount{
+						ConfigName:    "app-secret",
+						ContainerPath: "/run/secrets/app-secret",
+						Uid:           "1000",
+						Gid:           "1000",
+					},
 				},
 			},
 		},
@@ -65,15 +69,19 @@ func TestSecretSpecsFromCompose(t *testing.T) {
 			},
 			expectedSpecs: []api.SecretSpec{
 				{
-					Name:    "db-password",
-					Content: []byte("test secret content\n"),
+					ConfigSpec: api.ConfigSpec{
+						Name:    "db-password",
+						Content: []byte("test secret content\n"),
+					},
 				},
 			},
 			expectedMounts: []api.SecretMount{
 				{
-					SecretName:    "db-password",
-					ContainerPath: "/run/secrets/db-password",
-					Mode:          func() *os.FileMode { m := os.FileMode(0o400); return &m }(),
+					ConfigMount: api.ConfigMount{
+						ConfigName:    "db-password",
+						ContainerPath: "/run/secrets/db-password",
+						Mode:          func() *os.FileMode { m := os.FileMode(0o400); return &m }(),
+					},
 				},
 			},
 		},
@@ -96,19 +104,10 @@ func TestSecretSpecsFromCompose(t *testing.T) {
 }
 
 func TestSecretSpecEquals(t *testing.T) {
-	secret1 := api.SecretSpec{
-		Name: "test-secret",
-	}
+	secret1 := api.SecretSpec{ConfigSpec: api.ConfigSpec{Name: "test-secret"}}
+	secret2 := api.SecretSpec{ConfigSpec: api.ConfigSpec{Name: "test-secret"}}
+	secret3 := api.SecretSpec{ConfigSpec: api.ConfigSpec{Name: "test-secret", Content: []byte("some content")}}
 
-	secret2 := api.SecretSpec{
-		Name: "test-secret",
-	}
-
-	secret3 := api.SecretSpec{
-		Name:    "test-secret",
-		Content: []byte("some content"),
-	}
-
-	assert.True(t, secret1.Equals(secret2))
-	assert.False(t, secret1.Equals(secret3))
+	assert.True(t, secret1.Equals(secret2.ConfigSpec))
+	assert.False(t, secret1.Equals(secret3.ConfigSpec))
 }

--- a/pkg/client/compose/service.go
+++ b/pkg/client/compose/service.go
@@ -142,6 +142,15 @@ func ServiceSpecFromCompose(project *types.Project, serviceName string) (api.Ser
 	spec.Configs = configSpecs
 	spec.Container.ConfigMounts = configMounts
 
+	// Parse secrets
+	secretSpecs, secretMounts, err := secretSpecsFromCompose(project.Secrets, service.Secrets, project.WorkingDir)
+	if err != nil {
+		return spec, err
+	}
+
+	spec.Secrets = secretSpecs
+	spec.Container.SecretMounts = secretMounts
+
 	if h, ok := service.Extensions[PreDeployHookExtensionKey].(PreDeployHook); ok {
 		hook := &api.PreDeployHook{
 			Command:    h.Command,
@@ -480,9 +489,6 @@ func validateServicesFeatures(project *types.Project) []error {
 		}
 		if service.MemSwapLimit > 0 {
 			errs = append(errs, err(service.Name, "memswap_limit"))
-		}
-		if service.Secrets != nil {
-			errs = append(errs, err(service.Name, "secrets"))
 		}
 		if service.StorageOpt != nil {
 			errs = append(errs, err(service.Name, "storage_opt"))

--- a/pkg/client/compose/testdata/secret1.txt
+++ b/pkg/client/compose/testdata/secret1.txt
@@ -1,0 +1,1 @@
+test secret content

--- a/website/docs/8-compose-file-reference/1-support-matrix.md
+++ b/website/docs/8-compose-file-reference/1-support-matrix.md
@@ -42,7 +42,7 @@ If you rely on a specific Compose feature that is not supported by Uncloud, plea
 | `ports`                          | ⚠️ Limited         | `mode: host` only, use [`x-ports`](2-extensions.md#x-ports) for HTTP/HTTPS                                                                 |
 | `privileged`                     | ✅ Supported        | Run containers in privileged mode                                                                                                          |
 | `pull_policy`                    | ✅ Supported        | `always`, `missing`, `never`                                                                                                               |
-| `secrets`                        | ❌ Not supported    | Use configs or environment variables                                                                                                       |
+| `secrets`                        | ⚠️ Limited          | Supported, but handled as configs or environment variables, i.e. no additional encryption is applied                                       | 
 | `security_opt`                   | ❌ Not supported    |                                                                                                                                            |
 | `shm_size`                       | ✅ Supported        | Shared memory size                                                                                                                         |
 | `stop_grace_period`              | ✅ Supported        | Time to wait after SIGTERM before SIGKILL                                                                                                  |


### PR DESCRIPTION
This adds (limited) support for secrets. In the end we want to support the new 'secrets engine' from docker, but this still requires secrets to be put in a container.

This piggybacks on configs as much as possible to make the PR as small as possible.

We use /run/secrets to store them this is a tmpfs so nothing lands on disk.
If a container path is used, we symlink that to /run/secrets, so only a symlink lands on disk, not the secret it self.

When storing the container in corrosion we use base64 encryption, see the TODO there to do proper encrytion.

Update the compatiblity matrix to say we have limited support for secrets.

See: #75 and possibly #76

Note for #76, we will def. want to use the secrets engine of docker: https://github.com/docker/secrets-engine