### PR TITLE
fix: machine init/add fall back to plain output when stdout isn't a TTY (#386)

### DIFF
--- a/cmd/uncloud/machine/add.go
+++ b/cmd/uncloud/machine/add.go
@@ -163,19 +163,28 @@ func add(ctx context.Context, uncli *cli.CLI, remoteMachine *cli.RemoteMachine, 
 	}
 
 	// Wait for the cluster to be initialised on the machine to be able to deploy the Caddy service.
-	err = spinner.New().
-		Title(" Waiting for the machine to join the cluster...").
-		Type(spinner.MiniDot).
-		WithTheme(spinner.ThemeFunc(func(isDark bool) *spinner.Styles {
-			return &spinner.Styles{
-				Spinner: lipgloss.NewStyle().Foreground(lipgloss.Yellow),
-				Title:   lipgloss.NewStyle(),
-			}
-		})).
-		ActionWithErr(func(ctx context.Context) error {
-			return machineClient.WaitClusterReady(ctx, 5*time.Minute)
-		}).
-		Run()
+	// The spinner opens /dev/tty, so it dies headless (CI, SSH, mise tasks). Fall
+	// back to a plain wait when stdout isn't a terminal — mirrors
+	// connectClusterWithProgress, and lets `uc machine init/add` run without a PTY
+	// wrapper (errors surface normally instead of being swallowed).
+	if tui.IsStdoutTerminal() {
+		err = spinner.New().
+			Title(" Waiting for the machine to join the cluster...").
+			Type(spinner.MiniDot).
+			WithTheme(spinner.ThemeFunc(func(isDark bool) *spinner.Styles {
+				return &spinner.Styles{
+					Spinner: lipgloss.NewStyle().Foreground(lipgloss.Yellow),
+					Title:   lipgloss.NewStyle(),
+				}
+			})).
+			ActionWithErr(func(ctx context.Context) error {
+				return machineClient.WaitClusterReady(ctx, 5*time.Minute)
+			}).
+			Run()
+	} else {
+		fmt.Println("Waiting for the machine to join the cluster...")
+		err = machineClient.WaitClusterReady(ctx, 5*time.Minute)
+	}
 	if err != nil {
 		return fmt.Errorf("wait for machine to join the cluster: %w", err)
 	}

--- a/cmd/uncloud/machine/init.go
+++ b/cmd/uncloud/machine/init.go
@@ -14,6 +14,7 @@ import (
 	"github.com/psviderski/uncloud/cmd/uncloud/dns"
 	"github.com/psviderski/uncloud/internal/cli"
 	"github.com/psviderski/uncloud/internal/cli/config"
+	"github.com/psviderski/uncloud/internal/cli/tui"
 	"github.com/psviderski/uncloud/internal/machine/api/pb"
 	"github.com/psviderski/uncloud/internal/machine/cluster"
 	"github.com/psviderski/uncloud/internal/machine/network"
@@ -215,19 +216,27 @@ func initCluster(ctx context.Context, uncli *cli.CLI, remoteMachine *cli.RemoteM
 	// Since the cluster API needs a few moments to become ready after cluster initialisation,
 	// we keep the user informed during this wait. We wait here even if no Caddy or DNS is requested
 	// as the cluster needs to be ready so that commands such as 'uc machine ls' work immediately after init.
-	err = spinner.New().
-		Title(" Waiting for the cluster to be ready...").
-		Type(spinner.MiniDot).
-		WithTheme(spinner.ThemeFunc(func(isDark bool) *spinner.Styles {
-			return &spinner.Styles{
-				Spinner: lipgloss.NewStyle().Foreground(lipgloss.Yellow),
-				Title:   lipgloss.NewStyle(),
-			}
-		})).
-		ActionWithErr(func(ctx context.Context) error {
-			return client.WaitClusterReady(ctx, 1*time.Minute)
-		}).
-		Run()
+	// The spinner opens /dev/tty and dies headless (CI, SSH, mise tasks); fall back
+	// to a plain wait when stdout isn't a terminal so `uc machine init` works
+	// without a PTY wrapper (and errors surface instead of being swallowed).
+	if tui.IsStdoutTerminal() {
+		err = spinner.New().
+			Title(" Waiting for the cluster to be ready...").
+			Type(spinner.MiniDot).
+			WithTheme(spinner.ThemeFunc(func(isDark bool) *spinner.Styles {
+				return &spinner.Styles{
+					Spinner: lipgloss.NewStyle().Foreground(lipgloss.Yellow),
+					Title:   lipgloss.NewStyle(),
+				}
+			})).
+			ActionWithErr(func(ctx context.Context) error {
+				return client.WaitClusterReady(ctx, 1*time.Minute)
+			}).
+			Run()
+	} else {
+		fmt.Println("Waiting for the cluster to be ready...")
+		err = client.WaitClusterReady(ctx, 1*time.Minute)
+	}
 	if err != nil {
 		return fmt.Errorf("wait for cluster to be ready: %w", err)
 	}


### PR DESCRIPTION
Fixes #386.

`uc machine init` and `uc machine add` use `huh` readiness spinners that open `/dev/tty`, so they die in shells with no controlling terminal (CI, SSH automation, task runners) even with `-y`. Today the only workaround is wrapping the command in a PTY (`script -q /dev/null …`), which also swallows the real error on failure.

This guards both spinners with `tui.IsStdoutTerminal()` and falls back to a plain log + direct wait when stdout isn't a terminal — the exact pattern `connectClusterWithProgress` already uses. Headless now works without a PTY, and errors surface normally.

- `cmd/uncloud/machine/init.go` — "Waiting for the cluster to be ready..."
- `cmd/uncloud/machine/add.go` — "Waiting for the machine to join the cluster..."

No behaviour change in a terminal (spinner as before).