### PR TITLE
chore: use cli.Cancelled in all cases

### DIFF
--- a/cmd/uc/machine/rm.go
+++ b/cmd/uc/machine/rm.go
@@ -136,8 +136,7 @@ func remove(ctx context.Context, uncli *cli.CLI, nameOrID string, opts removeOpt
 			return fmt.Errorf("confirm removal: %w", err)
 		}
 		if !confirmed {
-			fmt.Println("Cancelled. Machine was not removed.")
-			return nil
+			return cli.Cancelled("Cancelled. Machine was not removed.")
 		}
 	}
 

--- a/cmd/uc/volume/rm.go
+++ b/cmd/uc/volume/rm.go
@@ -92,8 +92,7 @@ func remove(ctx context.Context, uncli *cli.CLI, names []string, opts removeOpti
 			return fmt.Errorf("confirm removal: %w", err)
 		}
 		if !confirmed {
-			fmt.Println("Cancelled. No volumes were removed.")
-			return nil
+			return cli.Cancelled("Cancelled. No volumes were removed.")
 		}
 	}
 


### PR DESCRIPTION
Use `cli.Cancelled` in all cases where we cancel an operation instead of Printf && return nil