### PR TITLE
Add machine: scale all global services

### DIFF
--- a/cmd/uc/machine/add.go
+++ b/cmd/uc/machine/add.go
@@ -2,21 +2,15 @@ package machine
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"net/netip"
 	"strings"
 	"time"
 
-	"charm.land/lipgloss/v2"
-	"github.com/docker/compose/v2/pkg/progress"
-	"github.com/psviderski/uncloud/cmd/uc/caddy"
 	"github.com/psviderski/uncloud/internal/cli"
 	"github.com/psviderski/uncloud/internal/cli/config"
 	"github.com/psviderski/uncloud/internal/cli/tui"
 	"github.com/psviderski/uncloud/internal/machine/network"
-	"github.com/psviderski/uncloud/pkg/api"
-	"github.com/psviderski/uncloud/pkg/client"
 	"github.com/spf13/cobra"
 )
 
@@ -81,7 +75,7 @@ Connection methods:
 		"Assign a name to the machine. (default is the machine's hostname)")
 	cmd.Flags().BoolVar(
 		&opts.noCaddy, "no-caddy", false,
-		"Don't deploy Caddy reverse proxy service to the machine.",
+		"Don't deploy Caddy reverse proxy service to the machine. This also cancels scaling any global services.",
 	)
 	cmd.Flags().BoolVar(
 		&opts.noInstall, "no-install", false,
@@ -187,81 +181,5 @@ func add(ctx context.Context, uncli *cli.CLI, remoteMachine *cli.RemoteMachine, 
 	}
 	fmt.Println("Machine joined the cluster.")
 
-	// TODO: scale the existing Caddy service to the new machine instead of running a new deployment
-	//  that may cause a small downtime.
-	// Deploy a Caddy service container to the added machine. If caddy service is already deployed on other machines,
-	// use the deployed image version.
-	// NOTE: We use the cluster client to inspect and scale the Caddy service because the newly added machine may have
-	// issues accessing the Machine API of existing machines in the cluster.
-	// See the issue for more details: https://github.com/psviderski/uncloud/issues/65.
-	caddyImage := ""
-	caddySvc, err := clusterClient.InspectService(ctx, client.CaddyServiceName)
-	if err != nil {
-		if errors.Is(err, api.ErrNotFound) {
-			// Caddy service is not deployed.
-			return nil
-		}
-		return fmt.Errorf("inspect caddy service: %w", err)
-	}
-	caddyImage = caddySvc.Containers[0].Container.Config.Image
-	// Find the latest created container and use its image.
-	var latestCreated time.Time
-	for _, c := range caddySvc.Containers[1:] {
-		created, err := time.Parse(time.RFC3339Nano, c.Container.Created)
-		if err != nil {
-			continue
-		}
-		if created.After(latestCreated) {
-			latestCreated = created
-			caddyImage = c.Container.Config.Image
-		}
-	}
-
-	fmt.Println()
-	fmt.Println("Preparing Caddy deployment...")
-	d, err := clusterClient.NewCaddyDeployment(caddyImage, "", api.Placement{})
-	if err != nil {
-		return fmt.Errorf("create caddy deployment: %w", err)
-	}
-
-	plan, err := d.Plan(ctx)
-	if err != nil {
-		return fmt.Errorf("plan caddy deployment: %w", err)
-	}
-
-	if len(plan.Operations) == 0 {
-		fmt.Printf("%s service is up to date.\n", client.CaddyServiceName)
-	} else {
-		fmt.Println(tui.Bold.Underline(true).Render("Deployment plan"))
-		fmt.Println()
-		fmt.Print(plan.Format())
-
-		summary := plan.FormatSummary()
-		fmt.Println(tui.Faint.Render(strings.Repeat("─", lipgloss.Width(summary))))
-		fmt.Println(summary)
-		fmt.Println()
-
-		if !opts.yes {
-			confirmed, err := tui.Confirm("Proceed with deployment?")
-			if err != nil {
-				return fmt.Errorf("confirm deployment: %w", err)
-			}
-			if !confirmed {
-				return cli.Cancelled("Caddy deploy cancelled. The machine has been added to the cluster.")
-			}
-		}
-
-		err = progress.RunWithTitle(ctx, func(ctx context.Context) error {
-			if _, err = d.Run(ctx); err != nil {
-				return fmt.Errorf("deploy caddy: %w", err)
-			}
-			return nil
-		}, uncli.ProgressOut(), fmt.Sprintf("Deploying service %s (%s mode)", d.Spec.Name, d.Spec.Mode))
-		if err != nil {
-			return err
-		}
-	}
-
-	fmt.Println()
-	return caddy.UpdateDomainRecords(ctx, machineClient, uncli.ProgressOut())
+	return scale(ctx, clusterClient, machineClient, uncli, opts.yes)
 }

--- a/cmd/uc/machine/scale.go
+++ b/cmd/uc/machine/scale.go
@@ -49,18 +49,18 @@ func scale(ctx context.Context, clusterClient, machineClient *client.Client, unc
 			}
 			d, err := clusterClient.NewCaddyDeployment(caddyImage, "", api.Placement{})
 			if err != nil {
-				return fmt.Errorf("create caddy deployment: %w", err)
+				return fmt.Errorf("create %s deployment: %w", service.Name, err)
 			}
-			plan, err = d.Plan(ctx)
+			if plan, err = d.Plan(ctx); err != nil {
+				return fmt.Errorf("plan %s deployment: %w", service.Name, err)
+			}
 
 		default:
 			spec := service.Containers[0].Container.ServiceSpec
 			d = clusterClient.NewDeployment(spec, nil)
-			plan, err = d.Plan(ctx)
-		}
-
-		if err != nil {
-			return fmt.Errorf("plan %s deployment: %w", service.Name, err)
+			if plan, err = d.Plan(ctx); err != nil {
+				return fmt.Errorf("plan %s deployment: %w", service.Name, err)
+			}
 		}
 
 		if len(plan.Operations) == 0 {

--- a/cmd/uc/machine/scale.go
+++ b/cmd/uc/machine/scale.go
@@ -48,10 +48,10 @@ func scale(ctx context.Context, clusterClient, machineClient *client.Client, unc
 				}
 			}
 			d, err := clusterClient.NewCaddyDeployment(caddyImage, "", api.Placement{})
-			plan, err = d.Plan(ctx)
 			if err != nil {
 				return fmt.Errorf("create caddy deployment: %w", err)
 			}
+			plan, err = d.Plan(ctx)
 
 		default:
 			spec := service.Containers[0].Container.ServiceSpec

--- a/cmd/uc/machine/scale.go
+++ b/cmd/uc/machine/scale.go
@@ -1,0 +1,120 @@
+package machine
+
+import (
+	"context"
+	"fmt"
+	"slices"
+	"strings"
+	"time"
+
+	"charm.land/lipgloss/v2"
+	"github.com/docker/compose/v2/pkg/progress"
+	"github.com/psviderski/uncloud/cmd/uc/caddy"
+	"github.com/psviderski/uncloud/internal/cli"
+	"github.com/psviderski/uncloud/internal/cli/tui"
+	"github.com/psviderski/uncloud/pkg/api"
+	"github.com/psviderski/uncloud/pkg/client"
+	"github.com/psviderski/uncloud/pkg/client/deploy"
+)
+
+// scale inspects all services and scales global ones to use the extra machine.
+func scale(ctx context.Context, clusterClient, machineClient *client.Client, uncli *cli.CLI, yes bool) error {
+	services, err := globalServices(ctx, clusterClient)
+	if err != nil {
+		return err
+	}
+
+	var (
+		d    *deploy.Deployment
+		plan deploy.ServicePlan
+	)
+	for _, service := range services {
+		switch service.Name {
+		case client.CaddyServiceName:
+			// NOTE: We use the cluster client to inspect and scale the Caddy service because the newly added machine may have
+			// issues accessing the Machine API of existing machines in the cluster.
+			// See the issue for more details: https://github.com/psviderski/uncloud/issues/65.
+			caddyImage := service.Containers[0].Container.Config.Image
+			// Find the latest created container and use its image.
+			var latestCreated time.Time
+			for _, c := range service.Containers[1:] {
+				created, err := time.Parse(time.RFC3339Nano, c.Container.Created)
+				if err != nil {
+					continue
+				}
+				if created.After(latestCreated) {
+					latestCreated = created
+					caddyImage = c.Container.Config.Image
+				}
+			}
+			d, err := clusterClient.NewCaddyDeployment(caddyImage, "", api.Placement{})
+			plan, err = d.Plan(ctx)
+			if err != nil {
+				return fmt.Errorf("create caddy deployment: %w", err)
+			}
+
+		default:
+			spec := service.Containers[0].Container.ServiceSpec
+			d = clusterClient.NewDeployment(spec, nil)
+			plan, err = d.Plan(ctx)
+		}
+
+		if err != nil {
+			return fmt.Errorf("plan %s deployment: %w", service.Name, err)
+		}
+
+		if len(plan.Operations) == 0 {
+			fmt.Printf("Service %s is up to date.\n", service.Name)
+			continue
+		}
+
+		if !yes {
+			confirmed, err := tui.Confirm("Proceed with deployment?")
+			if err != nil {
+				return fmt.Errorf("confirm deployment: %w", err)
+			}
+			if !confirmed {
+				fmt.Printf("Scaling %s cancelled.", service.Name)
+				continue
+			}
+		}
+
+		fmt.Println(tui.Bold.Underline(true).Render("Scaling plan"))
+		fmt.Println()
+		fmt.Print(plan.Format())
+
+		summary := plan.FormatSummary()
+		fmt.Println(tui.Faint.Render(strings.Repeat("─", lipgloss.Width(summary))))
+		fmt.Println(summary)
+		fmt.Println()
+
+		err = progress.RunWithTitle(ctx, func(ctx context.Context) error {
+			if _, err = d.Run(ctx); err != nil {
+				return fmt.Errorf("scale %s: %w", service.Name, err)
+			}
+			return nil
+		}, uncli.ProgressOut(), fmt.Sprintf("Scaling service %s (%s mode)", d.Spec.Name, d.Spec.Mode))
+		if err != nil {
+			return err
+		}
+		if service.Name == client.CaddyServiceName {
+			fmt.Println()
+			if err := caddy.UpdateDomainRecords(ctx, machineClient, uncli.ProgressOut()); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+func globalServices(ctx context.Context, clusterClient *client.Client) ([]api.Service, error) {
+	services, err := clusterClient.ListServices(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("list services: %w", err)
+	}
+
+	return slices.DeleteFunc(services, func(s api.Service) bool {
+		return s.Mode != api.ServiceModeGlobal
+	}), nil
+}

--- a/website/docs/9-cli-reference/uc_machine_add.md
+++ b/website/docs/9-cli-reference/uc_machine_add.md
@@ -22,7 +22,7 @@ uc machine add [USER@]HOST[:PORT] [flags]
 ```
   -h, --help                  help for add
   -n, --name string           Assign a name to the machine. (default is the machine's hostname)
-      --no-caddy              Don't deploy Caddy reverse proxy service to the machine.
+      --no-caddy              Don't deploy Caddy reverse proxy service to the machine. This also cancels scaling any global services.
       --no-install            Skip installation of Docker and the Uncloud daemon on the machine. Assumes they're already installed and running.
       --public-ip string      Public IP address of the machine for ingress configuration. Use 'auto' for automatic detection, blank '' or 'none' to disable ingress on this machine, or specify an IP address. (default "auto")
   -i, --ssh-key string        Path to SSH private key for remote login (if not already added to SSH agent). (default "~/.ssh/id_ed25519")


### PR DESCRIPTION
This lists all global services and scales them to the new machine that just was added. This re-uses a bunch of code from add.go in the new scale.go

Fixes: #388