### PR TITLE
Add STATUS column in service ls

### DIFF
--- a/cmd/uc/service/ls.go
+++ b/cmd/uc/service/ls.go
@@ -53,7 +53,7 @@ func list(ctx context.Context, uncli *cli.CLI) error {
 	t := tui.NewTable()
 
 	// Include the ID column if there are duplicate service names to differentiate them.
-	headers := []string{"NAME", "MODE", "REPLICAS", "IMAGE", "ENDPOINTS"}
+	headers := []string{"NAME", "MODE", "REPLICAS", "IMAGE", "STATUS", "ENDPOINTS"}
 	if haveDuplicateNames {
 		headers = append([]string{"ID"}, headers...)
 	}
@@ -76,7 +76,15 @@ func list(ctx context.Context, uncli *cli.CLI) error {
 			}
 		}
 
-		row := []string{s.Name, s.Mode, fmt.Sprintf("%d", len(s.Containers)), formattedImages, endpoints}
+		healthy := 0
+		for _, ctr := range s.Containers {
+			if ctr.Container.Healthy() {
+				healthy++
+			}
+		}
+		status := fmt.Sprintf("%d/%d healthy", healthy, len(s.Containers))
+
+		row := []string{s.Name, s.Mode, fmt.Sprintf("%d", len(s.Containers)), formattedImages, status, endpoints}
 		if haveDuplicateNames {
 			row = append([]string{s.ID}, row...)
 		}


### PR DESCRIPTION
```
% ./uc ls
AME              MODE         REPLICAS   IMAGE                                                 STATUS        ENDPOINTS
caddy             global       2          registry.science.ru.nl/cncz/sys/image/caddy:v0.1.35   2/2 healthy   (custom Caddy config)
caddy-extra       replicated   1          registry.science.ru.nl/cncz/sys/image/debug:v0.1.14   1/1 healthy   (custom Caddy config)
caddy-redis       replicated   1          redis:8.4-alpine                                      1/1 healthy
discourse-db      replicated   1          discourse/postgres:latest                             1/1 healthy
discourse-redis   replicated   1          redis:latest                                          1/1 healthy
discourse-web     replicated   1          discourse/discourse:latest                            0/1 healthy   https://discourse-web.web.u.science.ru.nl → :80, https://discourse.science.ru.nl → :80
ip                replicated   1          php:8.1-fpm-alpine                                    1/1 healthy   (custom Caddy config)
ip-data           replicated   1          ip/ip-data:2026-07-20-071158.e7380b2.dirty            1/1 healthy
unkey             global       2          registry.science.ru.nl/cncz/sys/image/unkey:v0.1.44   2/2 healthy
```

This supersedes #362 