### PR TITLE
secret: Resolve secrets in x-pre_deploy too

### DIFF
--- a/internal/machine/store/container.go
+++ b/internal/machine/store/container.go
@@ -92,6 +92,9 @@ func normaliseContainerForStore(ctr *api.ServiceContainer) {
 	// Remove the environment variables to avoid leaking secrets.
 	ctr.Config.Env = nil
 	ctr.ServiceSpec.Container.Env = nil
+	if ctr.ServiceSpec.PreDeploy != nil {
+		ctr.ServiceSpec.PreDeploy.Env = nil
+	}
 
 	// Docker returns Mounts in a non-deterministic order so sort them.
 	slices.SortFunc(ctr.Mounts, func(a, b container.MountPoint) int {

--- a/pkg/client/compose/secret.go
+++ b/pkg/client/compose/secret.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"maps"
 	"os"
 	"os/exec"
 	"strings"
@@ -132,9 +131,6 @@ func ResolveSecrets(ctx context.Context, project *types.Project) error {
 // a command.
 func HasCommandSecretRefs(project *types.Project) bool {
 	for _, service := range project.Services {
-		if predeploy, ok := service.Extensions[PreDeployHookExtensionKey].(PreDeployHook); ok {
-			maps.Copy(service.Environment, predeploy.Environment)
-		}
 		for _, v := range service.Environment {
 			if v == nil {
 				continue
@@ -145,6 +141,21 @@ func HasCommandSecretRefs(project *types.Project) bool {
 			}
 			if secret, ok := project.Secrets[name]; ok && secret.Driver == secretExecDriver {
 				return true
+			}
+
+			if predeploy, ok := service.Extensions[PreDeployHookExtensionKey].(PreDeployHook); ok {
+				for _, v := range predeploy.Environment {
+					if v == nil {
+						continue
+					}
+					name, ok := secretRefName(*v)
+					if !ok {
+						continue
+					}
+					if secret, ok := project.Secrets[name]; ok && secret.Driver == secretExecDriver {
+						return true
+					}
+				}
 			}
 		}
 	}

--- a/pkg/client/compose/secret.go
+++ b/pkg/client/compose/secret.go
@@ -147,7 +147,6 @@ func HasCommandSecretRefs(project *types.Project) bool {
 				return true
 			}
 		}
-
 	}
 	return false
 }

--- a/pkg/client/compose/secret.go
+++ b/pkg/client/compose/secret.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"maps"
 	"os"
 	"os/exec"
 	"strings"
@@ -105,6 +106,23 @@ func ResolveSecrets(ctx context.Context, project *types.Project) error {
 			}
 			service.Environment[k] = &value
 		}
+
+		if predeploy, ok := service.Extensions[PreDeployHookExtensionKey].(PreDeployHook); ok {
+			for k, v := range predeploy.Environment {
+				if v == nil {
+					continue
+				}
+				secretName, ok := secretRefName(*v)
+				if !ok {
+					continue
+				}
+				value, err := resolve(secretName)
+				if err != nil {
+					return err
+				}
+				predeploy.Environment[k] = &value
+			}
+		}
 	}
 
 	return nil
@@ -114,6 +132,9 @@ func ResolveSecrets(ctx context.Context, project *types.Project) error {
 // a command.
 func HasCommandSecretRefs(project *types.Project) bool {
 	for _, service := range project.Services {
+		if predeploy, ok := service.Extensions[PreDeployHookExtensionKey].(PreDeployHook); ok {
+			maps.Copy(service.Environment, predeploy.Environment)
+		}
 		for _, v := range service.Environment {
 			if v == nil {
 				continue
@@ -126,6 +147,7 @@ func HasCommandSecretRefs(project *types.Project) bool {
 				return true
 			}
 		}
+
 	}
 	return false
 }

--- a/pkg/client/compose/secret_test.go
+++ b/pkg/client/compose/secret_test.go
@@ -3,6 +3,7 @@ package compose
 import (
 	"context"
 	"fmt"
+	"maps"
 	"os"
 	"path/filepath"
 	"testing"
@@ -33,6 +34,9 @@ func resolvedEnv(t *testing.T, content, service string) types.MappingWithEquals 
 	project := loadProject(t, content)
 	require.NoError(t, ResolveSecrets(context.Background(), project))
 
+	if predeploy, ok := project.Services[service].Extensions[PreDeployHookExtensionKey].(PreDeployHook); ok {
+		maps.Copy(project.Services[service].Environment, predeploy.Environment)
+	}
 	return project.Services[service].Environment
 }
 
@@ -135,6 +139,22 @@ secrets:
     x-command: printf 'abc'
 `,
 			want: env(map[string]string{"PLAIN": "hello", "TOKEN": "abc"}),
+		},
+		{
+			name: "x-pre_deploy secret",
+			content: `
+services:
+  foo:
+    image: foo
+    x-pre_deploy:
+      command: echo foo
+      environment:
+        TOKEN: secret://token
+secrets:
+  token:
+    x-command: printf 'topsecret'
+`,
+			want: env(map[string]string{"TOKEN": "topsecret"}),
 		},
 	}
 


### PR DESCRIPTION
This adds the secret:// resolving to the Environment in x-pre_deploy too. Further more the Environment is set to nil when commiting the container to the store.

Fixes: #422