### PR TITLE
feat: validate remaining unsupported items of the support-matrix

### DIFF
--- a/pkg/client/compose/project_test.go
+++ b/pkg/client/compose/project_test.go
@@ -322,6 +322,40 @@ volumes:
 `,
 			shouldErr: true,
 		},
+		{
+			name: "external configs",
+			composeYAML: `services:
+  app:
+    image: myapp:latest
+configs:
+  http_config:
+    external: true
+`,
+			warnCount:    1,
+			warnContains: []string{"external"},
+		},
+		{
+			name: "container_name",
+			composeYAML: `services:
+  app:
+    image: myapp:latest
+    container_name: my_container
+`,
+			warnCount:    1,
+			warnContains: []string{"container_name"},
+		},
+		{
+			name: "placement",
+			composeYAML: `services:
+  app:
+    image: myapp:latest
+    deploy:
+      mode: replicated
+      replicas: 2
+`,
+			warnCount:    1,
+			warnContains: []string{"placement"},
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/client/compose/project_test.go
+++ b/pkg/client/compose/project_test.go
@@ -345,16 +345,55 @@ configs:
 			warnContains: []string{"container_name"},
 		},
 		{
-			name: "placement",
+			name: "deploy mode",
+			composeYAML: `services:
+  app:
+    image: myapp:latest
+    deploy:
+      mode: replicated-job
+      replicas: 2
+`,
+			warnCount:    1,
+			warnContains: []string{"deploy mode must"},
+		},
+		{
+			name: "deploy mode",
 			composeYAML: `services:
   app:
     image: myapp:latest
     deploy:
       mode: replicated
+      labels:
+        - foo
       replicas: 2
 `,
 			warnCount:    1,
-			warnContains: []string{"placement"},
+			warnContains: []string{"deploy labels"},
+		},
+		{
+			name: "deploy restart_policy",
+			composeYAML: `services:
+  app:
+    image: myapp:latest
+    deploy:
+      restart_policy:
+        condition: on-failure
+`,
+			warnCount:    1,
+			warnContains: []string{"deploy restart_policy"},
+		},
+		{
+			name: "deploy placement",
+			composeYAML: `services:
+  app:
+    image: myapp:latest
+    deploy:
+      placement:
+        preferences:
+          - spread: foo
+`,
+			warnCount:    1,
+			warnContains: []string{"deploy placement"},
 		},
 	}
 

--- a/pkg/client/compose/service.go
+++ b/pkg/client/compose/service.go
@@ -502,18 +502,26 @@ func validateServicesFeatures(project *types.Project) []error {
 			errs = append(errs, err(service.Name, "container_name"))
 		}
 		if service.Deploy != nil {
-			if len(service.Deploy.Placement.Constraints) > 0 || len(service.Deploy.Placement.Preferences) > 0 || service.Deploy.Placement.MaxReplicas > 0 || service.Deploy.Mode != "" {
+			if len(service.Deploy.Placement.Constraints) > 0 || len(service.Deploy.Placement.Preferences) > 0 {
 				errs = append(errs, fmt.Errorf(
-					"service '%s': placement is not supported, "+
+					"service '%s': deploy placement is not supported, "+
 						"use x-machines instead: %s", service.Name,
 					"https://uncloud.run/docs/compose-file-reference/extensions#x-machines"))
-				if service.Deploy.RestartPolicy != nil {
-					errs = append(errs, fmt.Errorf(
-						"service '%s': restart_policy defaults to 'unless-stopped'", service.Name))
-				}
-				if service.Deploy.RollbackConfig != nil {
-					errs = append(errs, err(service.Name, "rollback_config"))
-				}
+			}
+
+			if service.Deploy.RestartPolicy != nil {
+				errs = append(errs, fmt.Errorf(
+					"service '%s': deploy restart_policy defaults to 'unless-stopped'", service.Name))
+			}
+			if service.Deploy.Mode != "" && service.Deploy.Mode != "global" && service.Deploy.Mode != "replicated" {
+				errs = append(errs, fmt.Errorf(
+					"service '%s': deploy mode must either be 'global' or 'replicated'", service.Name))
+			}
+			if service.Deploy.RollbackConfig != nil {
+				errs = append(errs, err(service.Name, "deploy rollback_config"))
+			}
+			if len(service.Deploy.Labels) != 0 {
+				errs = append(errs, err(service.Name, "deploy labels"))
 			}
 		}
 		// we only allow the 'default' network, nothing else.

--- a/pkg/client/compose/service.go
+++ b/pkg/client/compose/service.go
@@ -454,13 +454,22 @@ func validateServicesExtensions(project *types.Project) error {
 
 // validateServicesFeatures checks services for unsupported features and returns all found.
 func validateServicesFeatures(project *types.Project) []error {
-	err := func(service, feature string) error {
-		return fmt.Errorf("service '%s': unsupported feature '%s', see %s",
-			service, feature, "https://uncloud.run/docs/compose-file-reference/support-matrix")
+	// XXX(miek): as of Sep 2026 these checks are in check with the support-matrix, except for a short syntax
+	// check.
+	var errs []error
+	const supportmatrix = "https://uncloud.run/docs/compose-file-reference/support-matrix"
+
+	for _, config := range project.Configs {
+		if config.External {
+			errs = append(errs, fmt.Errorf("config '%s': unsupported feature '%s', see %s",
+				config.Name, "external", supportmatrix))
+		}
 	}
 
-	// TODO: check other commonly used but unsupported features.
-	var errs []error
+	err := func(service, feature string) error {
+		return fmt.Errorf("service '%s': unsupported feature '%s', see %s",
+			service, feature, supportmatrix)
+	}
 	for _, service := range project.Services {
 		if service.SecurityOpt != nil {
 			errs = append(errs, err(service.Name, "security_opt"))
@@ -488,6 +497,24 @@ func validateServicesFeatures(project *types.Project) []error {
 		}
 		if service.StorageOpt != nil {
 			errs = append(errs, err(service.Name, "storage_opt"))
+		}
+		if service.ContainerName != "" {
+			errs = append(errs, err(service.Name, "container_name"))
+		}
+		if service.Deploy != nil {
+			if len(service.Deploy.Placement.Constraints) > 0 || len(service.Deploy.Placement.Preferences) > 0 || service.Deploy.Placement.MaxReplicas > 0 || service.Deploy.Mode != "" {
+				errs = append(errs, fmt.Errorf(
+					"service '%s': placement is not supported, "+
+						"use x-machines instead: %s", service.Name,
+					"https://uncloud.run/docs/compose-file-reference/extensions#x-machines"))
+				if service.Deploy.RestartPolicy != nil {
+					errs = append(errs, fmt.Errorf(
+						"service '%s': restart_policy defaults to 'unless-stopped'", service.Name))
+				}
+				if service.Deploy.RollbackConfig != nil {
+					errs = append(errs, err(service.Name, "rollback_config"))
+				}
+			}
 		}
 		// we only allow the 'default' network, nothing else.
 		if x := service.Networks; x != nil {


### PR DESCRIPTION
Validate unsupported compose features: external configs, container_name, and placement.

This makes the code match the support-matrix as of now (added comment to that effect as well).